### PR TITLE
Fix documentation error

### DIFF
--- a/dbc2val/Readme.md
+++ b/dbc2val/Readme.md
@@ -65,7 +65,6 @@ See "Steps for a local test with replaying a can dump file"
 1. Run the dbcfeeder.py
 
    ```bash
-   cd feeder_can
    ./dbcfeeder.py
    ```
 
@@ -78,7 +77,6 @@ See "Steps for a local test with replaying a can dump file"
 1. Run the dbcfeeder.py
 
    ```bash
-   cd feeder_can
    ./dbcfeeder.py
    ```
 


### PR DESCRIPTION
There is no folder `feeder_can`. 

Signed-off-by: Erik Jaegervall <erik.jaegervall@se.bosch.com>