### PR TITLE
Use same condition for ghcr upload and close

### DIFF
--- a/.github/workflows/clean-images.yml
+++ b/.github/workflows/clean-images.yml
@@ -10,11 +10,29 @@ env:
   GPSIMAGE_NAME: ${{ github.repository }}/gps
 
 jobs:
+  check_tokens:
+    runs-on: ubuntu-latest
+    outputs:
+      have_secrets: ${{ steps.check-secrets.outputs.have_secrets }}
+    
+    steps:
+    #Check we have access to secrets. Forks do not
+    - name: check for secrets needed to upload to ghcr
+      id: check-secrets
+      run: |
+          if [ ! -z "${{ secrets.PUSH_CONTAINER_TOKEN }}" ]; then
+            echo "Has token. Will delete images ghcr.io"
+            echo "::set-output name=have_secrets::true"
+          else
+            echo "No token detected, will do nothing!"
+            echo "::set-output name=have_secrets::false"
+          fi
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     
     steps:    
     - name: Delete ephemereal GPS images from registry
+      if: needs.check_tokens.outputs.have_secrets == 'true'
       uses: bots-house/ghcr-delete-image-action@v1.0.0
       with:
          owner: eclipse


### PR DESCRIPTION
To avoid failed builds if there are no tokens. Previously most builds failed, see https://github.com/eclipse/kuksa.val.feeders/actions/workflows/clean-images.yml

```
Run bots-house/ghcr-delete-image-action@v1.0.0
  with:
    owner: eclipse
    name: kuksa.val.feeders/gps
    tag: pr-17
  env:
    REGISTRY: ghcr.io
    GPSIMAGE_NAME: eclipse/kuksa.val.feeders/gps
Error: Input required and not supplied: token
```

Tested that ignoring cleaning works if there is no token in: https://github.com/eclipse/kuksa.val.feeders/actions/runs/2933358224

Signed-off-by: Erik Jaegervall <erik.jaegervall@se.bosch.com>