### PR TITLE
Upgrade docker build environment for gps2val

### DIFF
--- a/.github/workflows/kuksa_gps_feeder.yml
+++ b/.github/workflows/kuksa_gps_feeder.yml
@@ -16,7 +16,7 @@ jobs:
       registry: ${{ steps.check-secrets.outputs.registry }}
     
     steps:
-    #Check we have access to secrets. Forks fo not
+    #Check we have access to secrets. Forks do not
     - name: check for secrets needed to run demo
       id: check-secrets
       run: |
@@ -32,6 +32,8 @@ jobs:
   build:
     runs-on: self-hosted
     needs: [check_push_rights]
+    # As long as we use GRPCIO and Alpine we might need to build grpc for aarch64 which sometimes takes long time
+    timeout-minutes: 120
 
     steps:
     - uses: actions/checkout@v2

--- a/gps2val/Dockerfile
+++ b/gps2val/Dockerfile
@@ -7,16 +7,18 @@
 #
 
 
-FROM python:3.8-alpine
+FROM python:3.10-alpine as build
 
 LABEL org.opencontainers.image.source="https://github.com/eclipse/kuksa.val.feeders"
 LABEL org.opencontainers.image.authors="Wenwen.Chen@de.bosch.com"
 
-
-RUN apk --no-cache update && apk  --no-cache add gpsd
+# alpine-sdk and linux-headers needed for Alpine to build grpcio for aarch64, not needed for platforms with prebuilt grpcio
+RUN apk update && apk add gpsd alpine-sdk linux-headers
 ADD . /kuksa_gps_feeder
 WORKDIR /kuksa_gps_feeder
-RUN pip install --no-cache-dir -r requirements.txt 
+RUN pip install --upgrade pip
+# Note - Installing grpcio (inherited from kuksa-viss-client) takes very long time (40-60 minutes) on Alpine
+RUN pip install --no-cache-dir -r requirements.txt
 ENV PYTHONUNBUFFERED=yes
 
 ENV GPSD_SOURCE=udp://0.0.0.0:29998

--- a/gps2val/readme.md
+++ b/gps2val/readme.md
@@ -4,7 +4,7 @@ The [`gpsd_feeder.ini`](./config/gpsd_feeder.ini) contains `kuksa.val` and `gpsd
 
 Before starting the gps feeder, you need start `kuksa.val` and `gpsd`:
 ```
-<path to kuksa.val>/kuksa.val
+<path to kuksa.val>/kuksa-val-server
 
 gpsd -S <gpsd port> -N <gps device>
 ```
@@ -42,9 +42,11 @@ Keep in mind, that GPSd normally only listens on localhost/loopback interface. T
 You can also use [gpsfake](https://gpsd.gitlab.io/gpsd/gpsfake.html) to playback a gps logs in e.g. nmea format.
 To install `gpsfake`, follow the command in this [link](https://command-not-found.com/gpsfake).
 After installation, run the following command to simulate a gps device as datasource:
+
 ```
 gpsfake -P 2947 simplelog_example.nmea
 ```
+
 Note: You need to use the `gpsfake` with the same version like the installed `gpsd`.
 
 There are several tools for generating nmea log files:


### PR DESCRIPTION
Background:
gps2val relies on kuksa-viss-client. For Alpine docker env there is no prebuilt grpcio for aarch64 so the build action need to build it itself. The grpcio wheel does not seem to include all dependencies required, like linux-headers.

Now aligning Dockerfile with https://github.com/eclipse/kuksa.val/blob/master/kuksa_viss_client/Dockerfile.
See also https://github.com/eclipse/kuksa.val/issues/367 for general discussions on grpc/arrach64/Alpine

Signed-off-by: Erik Jaegervall <erik.jaegervall@se.bosch.com>