### PR TITLE
Update readme.md and correct spelling

### DIFF
--- a/dbc2val/Readme.md
+++ b/dbc2val/Readme.md
@@ -208,7 +208,7 @@ xxx: # CAN signal name taken from the used dbc file
   vss: # vss definition
     datatype: xxx # type of the data
     type: xxx # type of the value
-    unit: xxx # untie of the value
+    unit: xxx # unit of the value
     description: # description of the value
   databroker:
     datatype: xxx # The value ist taken from ../swdc-os-vehicleapi/feeder_can/gen_proto/sdv/databroker/v1/types_pb2.py
@@ -226,7 +226,7 @@ UIspeed_signed257: # CAN signal name taken from the used dbc file
   vss: # vss definition
     datatype: float # type of the data
     type: sensor # type of the value
-    unit: km/h # untie of the value
+    unit: km/h # unit of the value
     description: vehicle speed # description of the value
  databroker:
     datatype: 10 # FLOAT The value ist taken from ../swdc-os-vehicleapi/feeder_can/gen_proto/sdv/databroker/v1/types_pb2.py


### PR DESCRIPTION
Change `untie` to `unit`. I hate to be the guy correcting small changes..but this caught my eye. Looking forward to contributing more meaningful work in the future.