### PR TITLE
Update GPS feeder to new python lib

### DIFF
--- a/gps2val/gpsd_feeder.py
+++ b/gps2val/gpsd_feeder.py
@@ -34,7 +34,7 @@ from gpsdclient import GPSDClient
 
 scriptDir= os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(scriptDir, "../../"))
-from kuksa_viss_client import KuksaClientThread
+from kuksa_client import KuksaClientThread
 
 class Kuksa_Client():
 
@@ -47,8 +47,9 @@ class Kuksa_Client():
         provider_config=config['kuksa_val']
         self.client = KuksaClientThread(provider_config)
         self.client.start()
-        print("authorizing...")
-        self.client.authorize()
+        if provider_config.get('protocol') == 'ws':
+            print("authorizing...")
+            self.client.authorize('../../kuksa_certificates/jwt/all-read-write.json')
         
     def shutdown(self):
         self.client.stop()

--- a/gps2val/readme.md
+++ b/gps2val/readme.md
@@ -2,10 +2,8 @@
 consumes [gpsd](https://gpsd.gitlab.io/gpsd/) as datasource and pushes location to kuksa.val server.
 The [`gpsd_feeder.ini`](./config/gpsd_feeder.ini) contains `kuksa.val` and `gpsd` configuration.
 
-Before starting the gps feeder, you need start `kuksa.val` and `gpsd`:
+Before starting the gps feeder, you need to start `kuksa.val server/databroker` (for this have a look at [KUKSA.val server](../../kuksa-val-server/README.md) and [KUKSA.val databroker](../../kuksa_databroker/README.md)). You have to start an instance of `gpsd` by running:
 ```
-<path to kuksa.val>/kuksa-val-server
-
 gpsd -S <gpsd port> -N <gps device>
 ```
 
@@ -34,7 +32,7 @@ To run:
 docker run -it -p 29998:29998/udp -v $PWD/config:/config gpsd_feeder
 ```
 
-The container contains an internal gpsd daemon and the exposed UDP port can be used to feed NMEA data e.g. with [gpsd-forward](https://github.com/tiagoshibata/Android-GPSd-Forwarder) frm an Android phone. If you already have a configured GPSd, just modify the config file to point to it.
+The container contains an internal gpsd daemon and the exposed UDP port can be used to feed NMEA data e.g. with [gpsd-forward](https://github.com/tiagoshibata/Android-GPSd-Forwarder) from an Android phone. If you already have a configured GPSd, just modify the config file to point to it.
 
 Keep in mind, that GPSd normally only listens on localhost/loopback interface. To connect it from another interface start gpsd with the `-D` option
 

--- a/gps2val/requirements.txt
+++ b/gps2val/requirements.txt
@@ -1,2 +1,2 @@
 kuksa-viss-client
-gps
+gpsdclient


### PR DESCRIPTION
Using a library for a lightweight gpsd client isntead of the provided client library of the gpsd project, because this client gets more frequently released as pip package. Also this ports to the use of the new python library which is compliant either to KUKSA.val server or databaroker.