### PR TITLE
Add support for J1939 argument

### DIFF
--- a/dbc2val/Readme.md
+++ b/dbc2val/Readme.md
@@ -325,7 +325,7 @@ the OBD chipst, you need to enable Acks, otherwise the CAN sender will go into e
 When the target DBC file and ECU follow the SAE-J1939 standard, the CAN reader application of the feeder should read
 PGN(Parameter Group Number)-based Data rather than CAN frames directly. Otherwise it is possible to miss signals from
 large-sized messages that are delivered with more than one CAN frame because the size of each of these messages is bigger
-than a CAN frame's maximum payload of 8 bytes. To enable the J1939 mode, simply put `--j1939` in the command when running `dbcfeeder.py`.
+than a CAN frame's maximum payload of 8 bytes. To enable the J1939 mode, simply put `--use-j1939` in the command when running `dbcfeeder.py`.
 Prior to using this feature, j1939 and the relevant wheel-packages should be installed first:
 
 ```console

--- a/dbc2val/dbcfeeder.py
+++ b/dbc2val/dbcfeeder.py
@@ -392,7 +392,9 @@ def main(argv):
         print("ERROR:\nNo CAN port specified")
         return -1
 
-    if os.environ.get("USE_J1939"):
+    if args.use_j1939:
+        use_j1939 = True
+    elif os.environ.get("USE_J1939"):
         use_j1939 = os.environ.get("USE_J1939") == "1"
     elif "can" in config:
         use_j1939 = config["can"].getboolean("j1939", False)


### PR DESCRIPTION
By some reason it seems that we do not care about `--use-j1939`, even if it is mentioned in documentation.
This PR fixes that.

Note: I have only tested that we try to start the j1939 parser if `--use-j1939` is used. I have not tested that j1939 runs succesfully.

Signed-off-by: Erik Jaegervall <erik.jaegervall@se.bosch.com>