### PR TITLE
gps feeder fixes and improvements

### DIFF
--- a/.github/actions/post-container-location/action.yml
+++ b/.github/actions/post-container-location/action.yml
@@ -35,9 +35,10 @@ runs:
   steps:
     - shell: bash
       run: |
-        echo "## :rocket: Something new is in the world" >> $GITHUB_STEP_SUMMARY
-        echo -e "\nImages for testing temporarily available at \`${{ inputs.image }}\`" >> $GITHUB_STEP_SUMMARY
-        echo -e "\n\`\`\`\ndocker pull ${{ inputs.image }} ${{ inputs.docker-run-args }}\n\`\`\`" >> $GITHUB_STEP_SUMMARY
+        echo "## :rocket: New image is pushed" >> $GITHUB_STEP_SUMMARY
+        echo -e "\nImage for testing temporarily available at \`${{ inputs.image }}\`" >> $GITHUB_STEP_SUMMARY
+        echo -e "\n\`\`\`\ndocker pull ${{ inputs.image }}\n\`\`\`" >> $GITHUB_STEP_SUMMARY
+        echo -e "\n\`\`\`\ndocker run ${{ inputs.docker-run-args }} ${{ inputs.image }}\n\`\`\`" >> $GITHUB_STEP_SUMMARY
         if [ -n "${{ inputs.message }}" ]; then
           echo -e "\n${{ inputs.message }}" >> $GITHUB_STEP_SUMMARY
         fi

--- a/.github/actions/post-container-location/action.yml
+++ b/.github/actions/post-container-location/action.yml
@@ -1,0 +1,43 @@
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+name: Post container location
+description: Post snippet to pull and run test container
+
+inputs:
+  image:
+    required: true
+    type: string
+    description: The OCI image
+
+  docker-run-args:
+    required: false
+    type: string
+    description: Optional docker run arguments
+
+  message:
+    required: false
+    type: string
+    description: Optional message to log
+
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      run: |
+        echo "## :rocket: Something new is in the world" >> $GITHUB_STEP_SUMMARY
+        echo -e "\nImages for testing temporarily available at \`${{ inputs.image }}\`" >> $GITHUB_STEP_SUMMARY
+        echo -e "\n\`\`\`\ndocker pull ${{ inputs.image }} ${{ inputs.docker-run-args }}\n\`\`\`" >> $GITHUB_STEP_SUMMARY
+        if [ -n "${{ inputs.message }}" ]; then
+          echo -e "\n${{ inputs.message }}" >> $GITHUB_STEP_SUMMARY
+        fi

--- a/.github/workflows/check_push_rights.yml
+++ b/.github/workflows/check_push_rights.yml
@@ -5,33 +5,74 @@ on:
         description: "In possession of ghcr.io tokens?"
         value: ${{ jobs.check_push_rights.outputs.have_secrets }}
 
-
 jobs:
   check_push_rights:
     runs-on: ubuntu-latest
+
     outputs:
       have_secrets: ${{ steps.check-secrets.outputs.have_secrets }}
 
     steps:
-    #Check we have access to secrets for pushing to GHCR. Forks do not
-    - name: check GITHUB_TOKEN allows GHCR push access
+
+    - name: Dump GitHub Context
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: |
+        echo "$GITHUB_CONTEXT" | grep -v '"token":'
+
+    - name: GitHub Context Summary
+      run: |
+        echo "github {"
+        echo "  event_name: [${{ github.event_name }}]",
+        echo "  repository: [${{ github.repository }}]",
+        echo "  repository_owner: [${{ github.repository_owner }}]",
+        echo "  secret_source: [${{ github.secret_source }}]",
+        echo "  event.workflow: [${{ github.event.workflow}}]",
+        echo "  event.repository.fork: ${{ github.event.repository.fork }}",
+        echo "  event.repository.full_name: [${{ github.event.repository.full_name }}]",
+        echo "  event.pull_request.base.label: [${{ github.event.pull_request.base.label }}]",
+        echo "  event.pull_request.head.label: [${{ github.event.pull_request.head.label }}]"
+        echo "}"
+      shell: bash
+
+    # Check we have access to secrets for pushing to GHCR. Forks do not
+    - name: Check GITHUB_TOKEN allows GHCR push access
       id: check-secrets
       run: |
-          if [[ ${{ github.event_name }} == "push"  ]] &&  [[ ${{ github.repository }} == "eclipse/kuksa.val.feeders"  ]]; then
-            echo "We are pushing to kuksa.val.feeders upstream, so we should have rights"
-            echo "have_secrets=true" >> $GITHUB_OUTPUT
-            exit 0
-            # if it is a pull_request and my_repo is kuksa.val.feeders I can push to GHCR,
-            # (note that some/all workflows int his repo might still opt to no push PR builds to GHCR)
-          fi
-          if [[ ${{ github.event_name }} == "pull_request"  ]] &&  [[ ${{ github.event.pull_request.head.repo.full_name }} == "eclipse/kuksa.val.feeders"  ]]; then
-              echo "We are an internal pull request , so we should have rights"
+
+          echo "# Checking [${{ github.event_name }}] event, running in [${{ github.repository }}] repository"
+
+          if [[ "${{ github.repository_owner }}" == "eclipse" ]]; then
+            if [[ "${{ github.event_name }}" == "push" ]]; then
+              echo "We are pushing to kuksa.val.feeders upstream, so we should have rights"
               echo "have_secrets=true" >> $GITHUB_OUTPUT
               exit 0
+              # if it is a pull_request and my_repo is kuksa.val.feeders I can push to GHCR,
+              # (note that some/all workflows in this repo might still opt to no push PR builds to GHCR)
+            fi
+            if [[ "${{ github.event_name }}" == "pull_request" ]] && [[ "${{ github.event.pull_request.head.repo.full_name }}" == eclipse/* ]]; then
+                echo "We are an internal pull request, so we should have rights"
+                echo "have_secrets=true" >> $GITHUB_OUTPUT
+                exit 0
+            fi
+          else
+            # non-eclipse forks could be less restrictive
+            if [[ "${{ github.secret_source }}" != "None" ]]; then
+                echo "We have a secret source [${{ github.secret_source }}], probably we should have rights"
+                echo "have_secrets=true" >> $GITHUB_OUTPUT
+                exit 0
+            fi
+            if [[ "${{ github.event.repository.fork }}" != "false" ]]; then
+                echo "We are a ${{ github.event_name }} in a forked repo, but don't have a secret source. Probably don't have rights"
+                echo "have_secrets=false" >> $GITHUB_OUTPUT
+                exit 0
+            fi
+            # assume we are a fork and have some rights to push in ghcr of that fork
           fi
+
           # Everything else
           echo "Seems we do not have rights to push"
-          echo "We are event ${{ github.event_name }} running in ${{ github.repository }}"
           echo "In case this is a PR it is coming from ${{ github.event.pull_request.head.repo.full_name }} "
           echo "have_secrets=false" >> $GITHUB_OUTPUT
+
       shell: bash

--- a/.github/workflows/kuksa_gps_feeder.yml
+++ b/.github/workflows/kuksa_gps_feeder.yml
@@ -3,48 +3,44 @@ name: kuksa_gps_feeder
 on:
   push:
     branches: [ main ]
+    tags:
+      - "v*.*.*"
   pull_request:
     branches: [ main ]
-    paths: 
+    paths:
+     - ".github/workflows/check_push_rights.yml"
      - ".github/workflows/kuksa_gps_feeder.yml"
      - "gps2val/**"
   workflow_dispatch:
-  
+
+env:
+  EPHEMERAL_IMAGE: "ttl.sh/kuksa.val.feefers/gps-${{ github.sha }}:1h"
 
 jobs:
-  check_push_rights:
-    runs-on: self-hosted
-    outputs:
-      have_secrets: ${{ steps.check-secrets.outputs.have_secrets }}
-      registry: ${{ steps.check-secrets.outputs.registry }}
-    
-    steps:
-    #Check we have access to secrets. Forks do not
-    - name: check for secrets needed to run demo
-      id: check-secrets
-      run: |
-          if [ ! -z "${{ secrets.PUSH_CONTAINER_TOKEN }}" ]; then
-            echo "Running from base repo. Will push to ghcr.io"
-            echo "::set-output name=have_secrets::true"
-            echo "::set-output name=registry::ghcr.io"
-          else
-            echo "No secrets for pushing. Will push ephemeral images to ttl.sh"
-            echo "::set-output name=have_secrets::false"
-            echo "::set-output name=registry::ttl.sh"
-          fi
-  build:
-    runs-on: self-hosted
-    needs: [check_push_rights]
-   
+
+  checkrights:
+    uses: ./.github/workflows/check_push_rights.yml
+    secrets: inherit
+
+  build-self-hosted:
+    if: ${{ github.repository_owner == 'eclipse' }}
+    runs-on: [ self-hosted ]
+    needs: checkrights
+
+    # With default permissions, release action fails on forks
+    permissions:
+      contents: read
+      packages: write
+
     steps:
     - uses: actions/checkout@v3
-        
+
     - name: Docker meta
       id: meta
-      uses: docker/metadata-action@v3.5.0
+      uses: docker/metadata-action@v4
       with:
         # list of Docker images to use as base name for tags
-        images: ghcr.io/eclipse/kuksa.val.feeders/gps
+        images: ghcr.io/${{ github.repository }}/gps
         # generate Docker tags based on the following events/attributes
         tags: |
           type=ref,event=branch
@@ -52,19 +48,22 @@ jobs:
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
           type=semver,pattern={{major}}
-      
-    - run: echo ${{ needs.check_push_rights.outputs.have_secrets }}
-      
+
+    - name: Check Rights
+      run: |
+        echo "### [self-hosted] event:[${{ github.event_name }}], have_secrets: ${{ needs.checkrights.outputs.have_secrets }}"
+      shell: bash
+
     - name: Log in to the Container registry
-      if: needs.check_push_rights.outputs.have_secrets == 'true'
+      if: needs.checkrights.outputs.have_secrets == 'true'
       uses: docker/login-action@v2
       with:
-          registry: ${{ needs.check_push_rights.outputs.registry }}
-          username: kuksa-bot
-          password: ${{ secrets.PUSH_CONTAINER_TOKEN }}
-                  
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Build and push KUKSA gps feeder container image and push to ghcr.io
-      if: ${{ needs.checkrights.outputs.have_secrets == 'true' && github.event_name != 'pull_request' }} 
+      if: ${{ needs.checkrights.outputs.have_secrets == 'true' && github.event_name != 'pull_request' }}
       uses: docker/build-push-action@v3
       with:
         platforms: |
@@ -74,10 +73,9 @@ jobs:
         push: true
         tags: |
           ${{ steps.meta.outputs.tags }}
-          ttl.sh/kuksa.val.feeders/gps-${{github.sha}}:1h
+          ${{ env.EPHEMERAL_IMAGE }}
         labels: ${{ steps.meta.outputs.labels }}
-        
-            
+
     - name: Build ephemereal KUKSA gps feeder and push to ttl.sh
       if:  ${{ needs.checkrights.outputs.have_secrets == 'false' || github.event_name == 'pull_request' }}
       uses: docker/build-push-action@v3
@@ -87,7 +85,102 @@ jobs:
           linux/arm64
         context: gps2val
         push: true
-        tags: "ttl.sh/kuksa.val.feeders/gps-${{github.sha}}:1h"
+        tags: ${{ env.EPHEMERAL_IMAGE }}
         labels: ${{ steps.meta.outputs.labels }}
-        
-  
+
+  build:
+    # we don't have self hosted runners on forked repos, to optimize builds just amd64 image will be built
+    if: ${{ github.repository_owner != 'eclipse' }}
+    runs-on: ubuntu-latest
+    needs: checkrights
+
+    # With default permissions, release action fails on forks
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v3
+
+    ## NOTE: Uncomment following step if you want to build arm64 image without self-hosted runner on eclipse. It needs ~3h to finish!
+
+    # - name: Set up QEMU
+    #   uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        # list of Docker images to use as base name for tags
+        images: ghcr.io/${{ github.repository }}/gps
+        # generate Docker tags based on the following events/attributes
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+
+    - name: Check Rights
+      run: |
+        echo "### event:[${{ github.event_name }}], have_secrets: ${{ needs.checkrights.outputs.have_secrets }}"
+      shell: bash
+
+    - name: Log in to the Container registry
+      if: needs.checkrights.outputs.have_secrets == 'true'
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push KUKSA gps feeder container image and push to ghcr.io
+      if: ${{ needs.checkrights.outputs.have_secrets == 'true' && github.event_name != 'pull_request' }}
+      uses: docker/build-push-action@v3
+      with:
+        platforms: |
+          linux/amd64
+        context: gps2val
+        push: true
+        tags: |
+          ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+
+    - name: Build ephemeral KUKSA gps feeder and push to ttl.sh
+      if:  ${{ needs.checkrights.outputs.have_secrets == 'false' || github.event_name == 'pull_request' }}
+      uses: docker/build-push-action@v3
+      with:
+        platforms: |
+          linux/amd64
+        context: gps2val
+        push: true
+        tags: ${{ env.EPHEMERAL_IMAGE }}
+        labels: ${{ steps.meta.outputs.labels }}
+
+    - name: Update ttl.sh Summary
+      if: ${{ needs.checkrights.outputs.have_secrets != 'true' || github.event_name == 'pull_request' }}
+      run: |
+        echo '## ttl.sh ephemeral image (valid for 1h)' >> $GITHUB_STEP_SUMMARY
+        echo '- pull the image' >> $GITHUB_STEP_SUMMARY
+        echo '  :package: ```docker pull ' ${{ env.EPHEMERAL_IMAGE }} '```' >> $GITHUB_STEP_SUMMARY
+        echo '- run the image' >> $GITHUB_STEP_SUMMARY
+        echo '  :rocket: ```docker run -it --rm ' ${{ env.EPHEMERAL_IMAGE }} '```' >> $GITHUB_STEP_SUMMARY
+        if [ "${{ github.repository_owner}}" != "eclipse" ]; then
+          echo '**NOTE:** Only **linux/amd64** is included (self-hosted runner not available on forks)' >> $GITHUB_STEP_SUMMARY
+        fi
+
+    - name: Update ghcr.io Summary
+      if: ${{ needs.checkrights.outputs.have_secrets == 'true' && github.event_name != 'pull_request' }}
+      run: |
+        echo '## ghcr.io image' >> $GITHUB_STEP_SUMMARY
+        echo '- pull the image' >> $GITHUB_STEP_SUMMARY
+        echo '  :package: ```docker pull '${{ steps.meta.outputs.tags }}'```' >> $GITHUB_STEP_SUMMARY
+        echo '- run the image' >> $GITHUB_STEP_SUMMARY
+        echo '  :rocket: ```docker run -it --rm '${{ steps.meta.outputs.tags }}'```' >> $GITHUB_STEP_SUMMARY
+        if [ "${{ github.repository_owner}}" != "eclipse" ]; then
+          echo '**NOTE:** Only **linux/amd64** is included (self-hosted runner not available on forks)' >> $GITHUB_STEP_SUMMARY
+        fi
+      shell: bash

--- a/.github/workflows/kuksa_gps_feeder.yml
+++ b/.github/workflows/kuksa_gps_feeder.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches: [ main ]
     paths:
+     - ".github/actions/post-container-location/action.yml"
      - ".github/workflows/check_push_rights.yml"
      - ".github/workflows/kuksa_gps_feeder.yml"
      - "gps2val/**"
@@ -62,6 +63,7 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+
     - name: Build and push KUKSA gps feeder container image and push to ghcr.io
       if: ${{ needs.checkrights.outputs.have_secrets == 'true' && github.event_name != 'pull_request' }}
       uses: docker/build-push-action@v3
@@ -74,6 +76,13 @@ jobs:
         tags: |
           ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+
+    - name: Posting ghcr.io Summary
+      if: ${{ needs.checkrights.outputs.have_secrets == 'true' && github.event_name != 'pull_request' }}
+      uses: ./.github/actions/post-container-location
+      with:
+        image: ${{ steps.meta.outputs.tags }}
+
 
     # NOTE: linux/arm64 platform removed as we are getting Error 413 from ttl.sh due to image size.
     # Only merging to main / release should build multiarch image and push to ghcr.io
@@ -88,30 +97,13 @@ jobs:
         tags: ${{ env.EPHEMERAL_IMAGE }}
         labels: ${{ steps.meta.outputs.labels }}
 
-    - name: Update ttl.sh Summary
-      if: ${{ needs.checkrights.outputs.have_secrets != 'true' || github.event_name == 'pull_request' }}
-      run: |
-        echo '## ttl.sh ephemeral image (valid for 1h)' >> $GITHUB_STEP_SUMMARY
-        echo '- pull the image' >> $GITHUB_STEP_SUMMARY
-        echo '  :package: ```docker pull ' ${{ env.EPHEMERAL_IMAGE }} '```' >> $GITHUB_STEP_SUMMARY
-        echo '- run the image' >> $GITHUB_STEP_SUMMARY
-        echo '  :rocket: ```docker run -it --rm ' ${{ env.EPHEMERAL_IMAGE }} '```' >> $GITHUB_STEP_SUMMARY
-        if [ "${{ github.repository_owner}}" != "eclipse" ]; then
-          echo '**NOTE:** Only **linux/amd64** is included (self-hosted runner not available on forks)' >> $GITHUB_STEP_SUMMARY
-        fi
+    - name: Posting ttl.sh Summary
+      if:  ${{ needs.checkrights.outputs.have_secrets == 'false' || github.event_name == 'pull_request' }}
+      uses: ./.github/actions/post-container-location
+      with:
+        image: ${{ env.EPHEMERAL_IMAGE }}
+        message: "**NOTE:** Only **linux/amd64** image is included (ttl.sh push fails on big images)"
 
-    - name: Update ghcr.io Summary
-      if: ${{ needs.checkrights.outputs.have_secrets == 'true' && github.event_name != 'pull_request' }}
-      run: |
-        echo '## ghcr.io image' >> $GITHUB_STEP_SUMMARY
-        echo '- pull the image' >> $GITHUB_STEP_SUMMARY
-        echo '  :package: ```docker pull '${{ steps.meta.outputs.tags }}'```' >> $GITHUB_STEP_SUMMARY
-        echo '- run the image' >> $GITHUB_STEP_SUMMARY
-        echo '  :rocket: ```docker run -it --rm '${{ steps.meta.outputs.tags }}'```' >> $GITHUB_STEP_SUMMARY
-        if [ "${{ github.repository_owner}}" != "eclipse" ]; then
-          echo '**NOTE:** Only **linux/amd64** is included (self-hosted runner not available on forks)' >> $GITHUB_STEP_SUMMARY
-        fi
-      shell: bash
 
   build:
     # we don't have self hosted runners on forked repos, to optimize builds just amd64 image will be built
@@ -162,6 +154,7 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+
     - name: Build and push KUKSA gps feeder container image and push to ghcr.io
       if: ${{ needs.checkrights.outputs.have_secrets == 'true' && github.event_name != 'pull_request' }}
       uses: docker/build-push-action@v3
@@ -174,6 +167,14 @@ jobs:
           ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
 
+    - name: Posting ghcr.io Summary
+      if: ${{ needs.checkrights.outputs.have_secrets == 'true' && github.event_name != 'pull_request' }}
+      uses: ./.github/actions/post-container-location
+      with:
+        image: ${{ steps.meta.outputs.tags }}
+        message: "**NOTE:** Only **linux/amd64** image is included (self-hosted runner not available on forks)"
+
+
     - name: Build ephemeral KUKSA gps feeder and push to ttl.sh
       if:  ${{ needs.checkrights.outputs.have_secrets == 'false' || github.event_name == 'pull_request' }}
       uses: docker/build-push-action@v3
@@ -185,27 +186,9 @@ jobs:
         tags: ${{ env.EPHEMERAL_IMAGE }}
         labels: ${{ steps.meta.outputs.labels }}
 
-    - name: Update ttl.sh Summary
-      if: ${{ needs.checkrights.outputs.have_secrets != 'true' || github.event_name == 'pull_request' }}
-      run: |
-        echo '## ttl.sh ephemeral image (valid for 1h)' >> $GITHUB_STEP_SUMMARY
-        echo '- pull the image' >> $GITHUB_STEP_SUMMARY
-        echo '  :package: ```docker pull ' ${{ env.EPHEMERAL_IMAGE }} '```' >> $GITHUB_STEP_SUMMARY
-        echo '- run the image' >> $GITHUB_STEP_SUMMARY
-        echo '  :rocket: ```docker run -it --rm ' ${{ env.EPHEMERAL_IMAGE }} '```' >> $GITHUB_STEP_SUMMARY
-        if [ "${{ github.repository_owner}}" != "eclipse" ]; then
-          echo '**NOTE:** Only **linux/amd64** is included (self-hosted runner not available on forks)' >> $GITHUB_STEP_SUMMARY
-        fi
-
-    - name: Update ghcr.io Summary
-      if: ${{ needs.checkrights.outputs.have_secrets == 'true' && github.event_name != 'pull_request' }}
-      run: |
-        echo '## ghcr.io image' >> $GITHUB_STEP_SUMMARY
-        echo '- pull the image' >> $GITHUB_STEP_SUMMARY
-        echo '  :package: ```docker pull '${{ steps.meta.outputs.tags }}'```' >> $GITHUB_STEP_SUMMARY
-        echo '- run the image' >> $GITHUB_STEP_SUMMARY
-        echo '  :rocket: ```docker run -it --rm '${{ steps.meta.outputs.tags }}'```' >> $GITHUB_STEP_SUMMARY
-        if [ "${{ github.repository_owner}}" != "eclipse" ]; then
-          echo '**NOTE:** Only **linux/amd64** is included (self-hosted runner not available on forks)' >> $GITHUB_STEP_SUMMARY
-        fi
-      shell: bash
+    - name: Posting ttl.sh Summary
+      if: ${{ needs.checkrights.outputs.have_secrets == 'false' || github.event_name == 'pull_request' }}
+      uses: ./.github/actions/post-container-location
+      with:
+        image: ${{ env.EPHEMERAL_IMAGE }}
+        message: "**NOTE:** Only **linux/amd64** image is included (self-hosted runner not available on forks)"

--- a/.github/workflows/kuksa_gps_feeder.yml
+++ b/.github/workflows/kuksa_gps_feeder.yml
@@ -82,6 +82,7 @@ jobs:
       uses: ./.github/actions/post-container-location
       with:
         image: ${{ steps.meta.outputs.tags }}
+        docker-run-args: "-it --rm"
 
 
     # NOTE: linux/arm64 platform removed as we are getting Error 413 from ttl.sh due to image size.
@@ -102,6 +103,7 @@ jobs:
       uses: ./.github/actions/post-container-location
       with:
         image: ${{ env.EPHEMERAL_IMAGE }}
+        docker-run-args: "-it --rm"
         message: "**NOTE:** Only **linux/amd64** image is included (ttl.sh push fails on big images)"
 
 
@@ -172,6 +174,7 @@ jobs:
       uses: ./.github/actions/post-container-location
       with:
         image: ${{ steps.meta.outputs.tags }}
+        docker-run-args: "-it --rm"
         message: "**NOTE:** Only **linux/amd64** image is included (self-hosted runner not available on forks)"
 
 
@@ -191,4 +194,5 @@ jobs:
       uses: ./.github/actions/post-container-location
       with:
         image: ${{ env.EPHEMERAL_IMAGE }}
+        docker-run-args: "-it --rm"
         message: "**NOTE:** Only **linux/amd64** image is included (self-hosted runner not available on forks)"

--- a/.github/workflows/kuksa_gps_feeder.yml
+++ b/.github/workflows/kuksa_gps_feeder.yml
@@ -76,13 +76,14 @@ jobs:
           ${{ env.EPHEMERAL_IMAGE }}
         labels: ${{ steps.meta.outputs.labels }}
 
+    # NOTE: linux/arm64 platform removed as we are getting Error 413 from ttl.sh due to image size.
+    # Only merging to main / release should build multiarch image and push to ghcr.io
     - name: Build ephemereal KUKSA gps feeder and push to ttl.sh
       if:  ${{ needs.checkrights.outputs.have_secrets == 'false' || github.event_name == 'pull_request' }}
       uses: docker/build-push-action@v3
       with:
         platforms: |
           linux/amd64
-          linux/arm64
         context: gps2val
         push: true
         tags: ${{ env.EPHEMERAL_IMAGE }}

--- a/.github/workflows/kuksa_gps_feeder.yml
+++ b/.github/workflows/kuksa_gps_feeder.yml
@@ -89,6 +89,31 @@ jobs:
         tags: ${{ env.EPHEMERAL_IMAGE }}
         labels: ${{ steps.meta.outputs.labels }}
 
+    - name: Update ttl.sh Summary
+      if: ${{ needs.checkrights.outputs.have_secrets != 'true' || github.event_name == 'pull_request' }}
+      run: |
+        echo '## ttl.sh ephemeral image (valid for 1h)' >> $GITHUB_STEP_SUMMARY
+        echo '- pull the image' >> $GITHUB_STEP_SUMMARY
+        echo '  :package: ```docker pull ' ${{ env.EPHEMERAL_IMAGE }} '```' >> $GITHUB_STEP_SUMMARY
+        echo '- run the image' >> $GITHUB_STEP_SUMMARY
+        echo '  :rocket: ```docker run -it --rm ' ${{ env.EPHEMERAL_IMAGE }} '```' >> $GITHUB_STEP_SUMMARY
+        if [ "${{ github.repository_owner}}" != "eclipse" ]; then
+          echo '**NOTE:** Only **linux/amd64** is included (self-hosted runner not available on forks)' >> $GITHUB_STEP_SUMMARY
+        fi
+
+    - name: Update ghcr.io Summary
+      if: ${{ needs.checkrights.outputs.have_secrets == 'true' && github.event_name != 'pull_request' }}
+      run: |
+        echo '## ghcr.io image' >> $GITHUB_STEP_SUMMARY
+        echo '- pull the image' >> $GITHUB_STEP_SUMMARY
+        echo '  :package: ```docker pull '${{ steps.meta.outputs.tags }}'```' >> $GITHUB_STEP_SUMMARY
+        echo '- run the image' >> $GITHUB_STEP_SUMMARY
+        echo '  :rocket: ```docker run -it --rm '${{ steps.meta.outputs.tags }}'```' >> $GITHUB_STEP_SUMMARY
+        if [ "${{ github.repository_owner}}" != "eclipse" ]; then
+          echo '**NOTE:** Only **linux/amd64** is included (self-hosted runner not available on forks)' >> $GITHUB_STEP_SUMMARY
+        fi
+      shell: bash
+
   build:
     # we don't have self hosted runners on forked repos, to optimize builds just amd64 image will be built
     if: ${{ github.repository_owner != 'eclipse' }}

--- a/.github/workflows/kuksa_gps_feeder.yml
+++ b/.github/workflows/kuksa_gps_feeder.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 env:
-  EPHEMERAL_IMAGE: "ttl.sh/kuksa.val.feefers/gps-${{ github.sha }}:1h"
+  EPHEMERAL_IMAGE: "ttl.sh/kuksa.val.feeders/gps-${{ github.sha }}:1h"
 
 jobs:
 
@@ -73,12 +73,11 @@ jobs:
         push: true
         tags: |
           ${{ steps.meta.outputs.tags }}
-          ${{ env.EPHEMERAL_IMAGE }}
         labels: ${{ steps.meta.outputs.labels }}
 
     # NOTE: linux/arm64 platform removed as we are getting Error 413 from ttl.sh due to image size.
     # Only merging to main / release should build multiarch image and push to ghcr.io
-    - name: Build ephemereal KUKSA gps feeder and push to ttl.sh
+    - name: Build ephemeral KUKSA gps feeder and push to ttl.sh
       if:  ${{ needs.checkrights.outputs.have_secrets == 'false' || github.event_name == 'pull_request' }}
       uses: docker/build-push-action@v3
       with:

--- a/gps2val/Dockerfile
+++ b/gps2val/Dockerfile
@@ -13,7 +13,7 @@ LABEL org.opencontainers.image.source="https://github.com/eclipse/kuksa.val.feed
 LABEL org.opencontainers.image.authors="Wenwen.Chen@de.bosch.com"
 
 # alpine-sdk and linux-headers needed for Alpine to build grpcio for aarch64, not needed for platforms with prebuilt grpcio
-RUN apk update && apk add gpsd alpine-sdk linux-headers
+RUN apk add --no-cache gpsd alpine-sdk linux-headers
 ADD . /kuksa_gps_feeder
 WORKDIR /kuksa_gps_feeder
 RUN pip install --upgrade pip
@@ -21,8 +21,14 @@ RUN pip install --upgrade pip
 RUN pip install --no-cache-dir -r requirements.txt
 ENV PYTHONUNBUFFERED=yes
 
-ENV GPSD_SOURCE=udp://0.0.0.0:29998
+ENV GPSD_PORT=29998
+ENV GPSD_SOURCE=udp://0.0.0.0:${GPSD_PORT}
 ENV GPSD_LISTENER_PORT=2948
 
-EXPOSE 29998/udp
-CMD gpsd -S ${GPSD_LISTENER_PORT} ${GPSD_SOURCE}; ./gpsd_feeder.py
+EXPOSE ${GPSD_PORT}/udp
+
+# allow overriding GSPD arguments
+ENV GPSD_OPTIONS="-S ${GPSD_LISTENER_PORT} ${GPSD_SOURCE}"
+
+# CMD gpsd GPSD_ARGS; ./gpsd_feeder.py
+ENTRYPOINT [ "./entrypoint.sh" ]

--- a/gps2val/Dockerfile
+++ b/gps2val/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright Robert Bosch GmbH, 2020. Part of the Eclipse Kuksa Project.
+# Copyright Robert Bosch GmbH, 2020-2023. Part of the Eclipse Kuksa Project.
 #
 # All rights reserved. This configuration file is provided to you under the
 # terms and conditions of the Eclipse Distribution License v1.0 which
@@ -9,16 +9,21 @@
 
 FROM python:3.10-alpine as build
 
-LABEL org.opencontainers.image.source="https://github.com/eclipse/kuksa.val.feeders"
-LABEL org.opencontainers.image.authors="Wenwen.Chen@de.bosch.com"
-
 # alpine-sdk and linux-headers needed for Alpine to build grpcio for aarch64, not needed for platforms with prebuilt grpcio
-RUN apk add --no-cache gpsd alpine-sdk linux-headers
+RUN apk add --no-cache alpine-sdk linux-headers
 ADD . /kuksa_gps_feeder
 WORKDIR /kuksa_gps_feeder
 RUN pip install --upgrade pip
 # Note - Installing grpcio (inherited from kuksa-viss-client) takes very long time (40-60 minutes) on Alpine
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --target /kuksa_gps_feeder --no-cache-dir -r requirements.txt
+
+
+FROM python:3.10-alpine
+
+RUN apk add --no-cache gpsd libstdc++
+COPY --from=build /kuksa_gps_feeder /kuksa_gps_feeder
+WORKDIR /kuksa_gps_feeder
+
 ENV PYTHONUNBUFFERED=yes
 
 ENV GPSD_PORT=29998

--- a/gps2val/Dockerfile
+++ b/gps2val/Dockerfile
@@ -1,11 +1,15 @@
-# Copyright Robert Bosch GmbH, 2020-2023. Part of the Eclipse Kuksa Project.
-#
-# All rights reserved. This configuration file is provided to you under the
-# terms and conditions of the Eclipse Distribution License v1.0 which
-# accompanies this distribution, and is available at
-# http://www.eclipse.org/org/documents/edl-v10.php
-#
-
+# /********************************************************************************
+# * Copyright (c) 2020-2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
 
 FROM python:3.10-alpine as build
 

--- a/gps2val/entrypoint.sh
+++ b/gps2val/entrypoint.sh
@@ -1,8 +1,18 @@
 #!/bin/sh
+#********************************************************************************
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License 2.0 which is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#*******************************************************************************/
 
-# ENV GPSD_ARGS="-S ${GPSD_LISTENER_PORT} ${GPSD_SOURCE}"
-# CMD gpsd GPSD_ARGS; ./gpsd_feeder.py
-
+# set defaut options if not set from Dockerfile
 [ -z "$GPSD_OPTIONS" ] && GPSD_OPTIONS="-S 2948 udp://0.0.0.0:29998"
 
 gpsd $GPSD_OPTIONS -N -D 2 &

--- a/gps2val/entrypoint.sh
+++ b/gps2val/entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# ENV GPSD_ARGS="-S ${GPSD_LISTENER_PORT} ${GPSD_SOURCE}"
+# CMD gpsd GPSD_ARGS; ./gpsd_feeder.py
+
+[ -z "$GPSD_OPTIONS" ] && GPSD_OPTIONS="-S 2948 udp://0.0.0.0:29998"
+
+gpsd $GPSD_OPTIONS -N -D 2 &
+if [ $? -eq 0 ]; then
+    export GPSD_PID=$$
+    echo "# gpsd started, PID: $GPSD_PID"
+else
+    echo "ERROR: Failed to start gpsd $GPSD_OPTIONS -N -D 2"
+fi
+
+trap cleanup 15
+
+cleanup() {
+    echo "# cleanup"
+    if [ -n "$GPSD_PID" ]; then
+        echo "# killng gpsd PID: $GPSD_PID"
+        kill -9 $GPSD_PID
+        unset GPSD_PID
+    fi
+}
+
+echo "# Launching: ./gpsd_feeder.py $*"
+python -u ./gpsd_feeder.py $*
+
+cleanup
+
+# check for remaining gpsd processes
+pidof gpsd

--- a/gps2val/gpsd_feeder.py
+++ b/gps2val/gpsd_feeder.py
@@ -1,19 +1,14 @@
 #! /usr/bin/env python
 
 ########################################################################
-# Copyright (c) 2020 Robert Bosch GmbH
+# Copyright (c) 2020-2023 Contributors to the Eclipse Foundation
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# This program and the accompanying materials are made available under the
+# terms of the Apache License 2.0 which is available at
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # SPDX-License-Identifier: Apache-2.0
 ########################################################################
@@ -22,7 +17,6 @@
 # formatted
 # lat,lon
 # All other values will be reported as 0
-
 
 import threading
 import configparser


### PR DESCRIPTION
Fixed several issues in gps2val:
**NOTE:** command line arguments are broken, to be addressed in another PR.
- Slightly reduced size of the image (apk cahce removed)
- Workaround for a sighandler deadlock in gpsd_feeder, preventing image from stopping: thread.join(1) + os._exit(1)
- Disabled SIGQUIT handler in order to force an app crash in case sighandler hangs in the future
- Added some extra dumps for config
- Dockerfile uses `entrypoint.sh` script to allow custom cmdline arguments to gpsd_feeder.py
**NOTE:** gpsd is started as background job and it has dumps now, `entrypoint.sh` makes sure gpsd is terminated after python exits. Also the image has a hardcoded config file, so command line args are overriden by it.

Also fixes and improvements in workflow file (e.g. make it git clone friendly):
- Improved github context checks to guess if we should have rights to push on `ghcr.io`
- Now should be able to run on forked repos (without self-hosted arm64 runner).
- In forked builds, just `linux/amd64` platform is built as qemu build for arm64 needs ~3h to finish.
- Added nice summary for ephemeral `ttl.sh` images / `ghcr.io` tags in workflow summary

Signed-off-by: Ivan Kirchev <Ivan.Kirchev@bosch.com>