### PR TITLE
Fix missing socketcan in dbc2val

### DIFF
--- a/dbc2val/Dockerfile
+++ b/dbc2val/Dockerfile
@@ -34,7 +34,7 @@ RUN /opt/venv/bin/python3 -m pip install --upgrade pip \
 RUN pip3 install wheel scons && pip3 install pyinstaller patchelf==0.17.0.0 staticx
 
 # By default we use certificates and tokens from kuksa_certificates, so they must be included
-RUN pyinstaller --collect-data kuksa_certificates --clean -F -s dbcfeeder.py
+RUN pyinstaller --collect-data kuksa_certificates --hidden-import can.interfaces.socketcan --clean -F -s dbcfeeder.py
 #   --debug=imports
 
 WORKDIR /dist


### PR DESCRIPTION
pyinstaller seems to be unable to detect the CAN library at build time. At runtime, the dbc2val cannot use the "--use-socket-can" feature as the library is missing. Informing pyinstaller about the hidden import let's it package the CAN library properly.