### PR TITLE
Update DBC provider action file to kuksa.val standard

### DIFF
--- a/.github/workflows/kuksa_dbc_feeder.yml
+++ b/.github/workflows/kuksa_dbc_feeder.yml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2022 Contributors to the Eclipse Foundation
+# * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.
@@ -27,65 +27,83 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
+    - name: Checkout Repository
+      uses: actions/checkout@v3
 
-      - name: Retrieve build binaries
-        uses: actions/download-artifact@v3
-        with:
-          path: ${{github.workspace}}
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        # list of Docker images to use as base name for tags
+        images: |
+          ghcr.io/eclipse/kuksa.val.feeders/dbc2val
+        # generate Docker tags based on the following events/attributes
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Log in to the Container registry
+      if: needs.checkrights.outputs.have_secrets == 'true'
+      uses: docker/login-action@v2
+      with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - id: repository-name-adjusted
-        name: Make repository name in lower case for docker upload.
-        uses: ASzc/change-string-case-action@v2
-        with:
-          string: ${{ github.repository }}
+    - name: Build DBC provider container container and push to ghcr.io (and ttl.sh)
+      id: ghcr-build
+      if: ${{ needs.checkrights.outputs.have_secrets == 'true' && github.event_name != 'pull_request' }}
+      uses: docker/build-push-action@v3
+      with:
+        platforms: |
+          linux/amd64
+          linux/arm64
+        file: ./dbc2val/Dockerfile
+        context: ./dbc2val/
+        push: true
+        tags: |
+          ${{ steps.meta.outputs.tags }}
+          ttl.sh/kuksa.val/kuksa-dbcprovider-${{github.sha}}
+        labels: ${{ steps.meta.outputs.labels }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+    - name: Build ephemeral DBC provider container and push to ttl.sh
+      if: ${{ needs.checkrights.outputs.have_secrets == 'false' || github.event_name == 'pull_request' }}
+      id: tmp-build
+      uses: docker/build-push-action@v3
+      with:
+        platforms: |
+          linux/amd64
+          linux/arm64
+        file: ./dbc2val/Dockerfile
+        context: ./dbc2val/
+        push: true
+        tags: "ttl.sh/kuksa.val/kuksa-dbcprovider-${{github.sha}}"
+        labels: ${{ steps.meta.outputs.labels }}
 
-      - name: "Build image"
-        id: image_build
-        uses: docker/build-push-action@v2
-        with:
-          pull: true
-          push: false
-          outputs: |
-            type=oci,dest=./dbc2val.tar
-          context: ./dbc2val
-          file: ./dbc2val/Dockerfile
-          platforms: linux/amd64, linux/arm64
-          tags: ${{ github.sha }}
-          labels: |
-            org.opencontainers.image.source=https://github.com/${{steps.repository-name-adjusted.outputs.lowercase}}
+    - name: Posting message
+      uses: ./.github/actions/post-container-location
+      with:
+        image: ttl.sh/kuksa.val/kuksa-dbcprovider-${{github.sha}}
 
-      - name: Temporarily save Docker image
-        uses: actions/upload-artifact@v3
-        with:
-          name: Container image
-          path: ${{github.workspace}}/dbc2val.tar
-          retention-days: 1
+    - name: Run dbc tests
+      run: |
+        cd dbc2val
+        pip3 install --no-cache-dir -r requirements.txt -r requirements-dev.txt
+        python -m pytest
 
-      - name: Run dbc tests
-        run: |
-          cd dbc2val
-          pip3 install --no-cache-dir -r requirements.txt -r requirements-dev.txt
-          python -m pytest
-
-      - name: Run pylint (but accept errors for now)
-        run: |
-          cd dbc2val
-          # First just show, never fail
-          pylint --exit-zero dbcfeeder.py dbcfeederlib test
-          # Fail on errors and above
-          pylint -E dbcfeeder.py dbcfeederlib test
+    - name: Run pylint (but accept errors for now)
+      run: |
+        cd dbc2val
+        # First just show, never fail
+        pylint --exit-zero dbcfeeder.py dbcfeederlib test
+        # Fail on errors and above
+        pylint -E dbcfeeder.py dbcfeederlib test


### PR DESCRIPTION
This updates DBC feeder CI, to use the same patterns and version as databroker,

Will push images for testing to ttl.sh, and should push correctly tagged images to ghcr.io upon workflow dispatch with a tag

dbc tests and pylint still in/not modified