### PR TITLE
Do not load CAN log into memory when replaying

### DIFF
--- a/dbc2val/dbcfeederlib/canplayer.py
+++ b/dbc2val/dbcfeederlib/canplayer.py
@@ -56,9 +56,9 @@ class CANplayer:
                 log.debug(f"Message sent on {self.bus.channel_info}")
                 log.debug(f"Message: {msg}")
             except can.CanError:
-                log.debug("Failed to send message via CAN bus")
+                log.error("Failed to send message via CAN bus")
 
-        log.debug("Replayed all messages from CAN log file")
+        log.info("Replayed all messages from CAN log file")
 
     def txWorker(self):
         log.info("Starting Tx thread")


### PR DESCRIPTION
Currently, a CAN dump file is being loaded into memory before starting to replay its frames to the databroker.
This PR changes the behavior to read the CAN frames from the dump file one-by-one instead of pre-loading the whole file into memory.