### PR TITLE
GPS Feeder Databroker authentication support

### DIFF
--- a/gps2val/Dockerfile
+++ b/gps2val/Dockerfile
@@ -19,7 +19,7 @@ ADD . /kuksa_gps_feeder
 WORKDIR /kuksa_gps_feeder
 RUN pip install --upgrade pip
 # Note - Installing grpcio (inherited from kuksa-viss-client) takes very long time (40-60 minutes) on Alpine
-RUN pip install --target /kuksa_gps_feeder --no-cache-dir -r requirements.txt
+RUN pip install --pre --target /kuksa_gps_feeder --no-cache-dir -r requirements.txt
 
 
 FROM python:3.10-alpine

--- a/gps2val/config/gpsd_feeder.ini
+++ b/gps2val/config/gpsd_feeder.ini
@@ -1,12 +1,12 @@
 [kuksa_val]
 # KUKSA.val server/databroker host name and port
-# ip = 127.0.0.1 
+# ip = 127.0.0.1
 # port = 8090 / 55555
 # protocol = ws / grpc
 # KUKSA.val databroker does not yet support security features
 # insecure = False / True
 # Paths to files that are needed: for default files see https://github.com/boschglobal/kuksa.val/tree/master/kuksa_certificates
-# token = your path to your token for authentication
+# token_or_tokenfile = your token or path to a file storing the token to be used for authentication
 # certificate = your path to Client.pem
 # cacertificate = your path to CA.pem
 # key = your path to Client.key

--- a/gps2val/gpsd_feeder.py
+++ b/gps2val/gpsd_feeder.py
@@ -20,115 +20,277 @@
 
 import threading
 import configparser
-import os, sys, json, signal
-import csv
+import os
+import sys
+import json
+import signal
 import time
-import queue
+import logging
 from gpsdclient import GPSDClient
 import argparse
-
-scriptDir= os.path.dirname(os.path.realpath(__file__))
-sys.path.append(os.path.join(scriptDir, "../../"))
 from kuksa_client import KuksaClientThread
+
+scriptDir = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(scriptDir, "../../"))
+
+
+log = logging.getLogger("gpsfeeder")
+
+
+def init_logging(loglevel):
+    # create console handler and set level to debug
+    console_logger = logging.StreamHandler()
+    console_logger.setLevel(logging.DEBUG)
+
+    # create formatter
+    if sys.stdout.isatty():
+        formatter = ColorFormatter()
+    else:
+        formatter = logging.Formatter(
+            fmt="%(asctime)s %(levelname)s %(name)s: %(message)s"
+        )
+
+    # add formatter to console_logger
+    console_logger.setFormatter(formatter)
+
+    # add console_logger as a global handler
+    root_logger = logging.getLogger()
+    root_logger.setLevel(loglevel)
+    root_logger.addHandler(console_logger)
+
+
+class ColorFormatter(logging.Formatter):
+    FORMAT = "{time} {{loglevel}} {logger} {msg}".format(
+        time="\x1b[2m%(asctime)s\x1b[0m",  # grey
+        logger="\x1b[2m%(name)s:\x1b[0m",  # grey
+        msg="%(message)s",
+    )
+    FORMATS = {
+        logging.DEBUG: FORMAT.format(loglevel="\x1b[34mDEBUG\x1b[0m"),  # blue
+        logging.INFO: FORMAT.format(loglevel="\x1b[32mINFO\x1b[0m"),  # green
+        logging.WARNING: FORMAT.format(loglevel="\x1b[33mWARNING\x1b[0m"),  # yellow
+        logging.ERROR: FORMAT.format(loglevel="\x1b[31mERROR\x1b[0m"),  # red
+        logging.CRITICAL: FORMAT.format(loglevel="\x1b[31mCRITICAL\x1b[0m"),  # red
+    }
+
+    def format(self, record):
+        log_fmt = self.FORMATS.get(record.levelno)
+        formatter = logging.Formatter(log_fmt)
+        return formatter.format(record)
+
+
+def parse_env_log(env_log, default=logging.INFO):
+    def parse_level(level, default=default):
+        if type(level) is str:
+            if level.lower() in [
+                "debug",
+                "info",
+                "warn",
+                "warning",
+                "error",
+                "critical",
+            ]:
+                return level.upper()
+            else:
+                raise Exception(f"could not parse '{level}' as a log level")
+        return default
+
+    loglevels = {}
+
+    if env_log is not None:
+        log_specs = env_log.split(",")
+        for log_spec in log_specs:
+            spec_parts = log_spec.split("=")
+            if len(spec_parts) == 1:
+                # This is a root level spec
+                if "root" in loglevels:
+                    raise Exception("multiple root loglevels specified")
+                else:
+                    loglevels["root"] = parse_level(spec_parts[0])
+            if len(spec_parts) == 2:
+                logger = spec_parts[0]
+                level = spec_parts[1]
+                loglevels[logger] = parse_level(level)
+
+    if "root" not in loglevels:
+        loglevels["root"] = default
+
+    return loglevels
+
 
 class Kuksa_Client():
 
     # Constructor
     def __init__(self, config):
-        print("Init kuksa client...")
+        log.info("Init kuksa client...")
         if "kuksa_val" not in config:
-            print("kuksa_val section missing from configuration, exiting")
+            log.error("kuksa_val section missing from configuration, exiting")
             sys.exit(-1)
-        provider_config=config['kuksa_val']
+        provider_config = config['kuksa_val']
         self.client = KuksaClientThread(provider_config)
         self.client.start()
-        if str(provider_config.get('protocol')) == 'ws':  # FIXME: and provider_config.get('insecure') != 'True'
-            print("authorizing...")
-            self.client.authorize(str(provider_config.get('token')))
+        token_string = str(provider_config.get('token_or_tokenfile'))
+        if token_string != "":
+            log.info(f"Token information provided is: {token_string}")
+        else:
+            log.info("No token information provided, "
+                     "subsequent errors expected if Server/Databroker requires authentication!")
+        connected = self.client.checkConnection()
+        log.info(f"Connection status is: {connected}")
+        self.messages_sent = 0
+        self.last_sent_log_entry = 0
 
     def shutdown(self):
         self.client.stop()
 
     def setData(self, data):
-        print(f"Update {data}")
-        for k,v in data.items():
+        log.debug(f"Update {data}")
+        for k, v in data.items():
             if v is not None:
-                self.client.setValue(k,str(v))
+                tmp_text = self.client.setValue(k, str(v))
+                log.debug(f"Got setValue response:{tmp_text}")
+                if (tmp_text == "OK"):
+                    # Databroker returns OK on successful calls, it only returns JSON in case of errors
+                    resp = {}
+                else:
+                    try:
+                        resp = json.loads(tmp_text)
+                    except json.decoder.JSONDecodeError:
+                        log.error(f"Unexpected response from Server/Databroker: {tmp_text}", exc_info=True)
+                        resp = {"error": tmp_text}
+                if "error" in resp:
+                    log.error(f"Error sending signal: {resp['error']}")
+                else:
+                    self.messages_sent += 1
+                    if self.messages_sent >= (2 * self.last_sent_log_entry):
+                        log.info(f"Number of VSS messages sent so far: {self.messages_sent}")
+                        self.last_sent_log_entry = self.messages_sent
+
 
 class GPSDClientThread(threading.Thread):
     def __init__(self, config, consumer):
         super(GPSDClientThread, self).__init__()
-        print("Init gpsd client...")
+        log.info("Init gpsd client...")
         if "gpsd" not in config:
-            print("gpsd section missing from configuration, exiting")
+            log.error("gpsd section missing from configuration, exiting")
             sys.exit(-1)
 
         self.consumer = consumer
-        provider_config=config['gpsd']
-        self.gpsd_host=provider_config.get('host','127.0.0.1')
-        self.gpsd_port=provider_config.get('port','2947')
+        provider_config = config['gpsd']
+        self.gpsd_host = provider_config.get('host', '127.0.0.1')
+        self.gpsd_port = provider_config.get('port', '2947')
         self.interval = provider_config.getint('interval', 1)
 
-        print("Trying to connect gpsd at "+str(self.gpsd_host)+" port "+str(self.gpsd_port))
+        log.info("Trying to connect gpsd at "+str(self.gpsd_host)+" port "+str(self.gpsd_port))
         self.client = GPSDClient(host=self.gpsd_host, port=self.gpsd_port)
 
-        self.collecteddata = {  }
         self.running = True
 
     def run(self):
-        print("gpsd receive loop started")
-        for result in self.client.dict_stream(filter=["TPV"]):
-            if self.running:
-                print("")
-                self.collecteddata['Vehicle.CurrentLocation.Latitude']= result.get('lat')
-                self.collecteddata['Vehicle.CurrentLocation.Longitude']= result.get('lon')
-                self.collecteddata['Vehicle.CurrentLocation.Altitude']= result.get('alt')
-                self.collecteddata['Vehicle.Speed']= result.get('speed')
-                self.collecteddata['Vehicle.CurrentLocation.Timestamp']= result.get('time')
-                self.collecteddata['Vehicle.CurrentLocation.Heading']= result.get('track')
-                self.collecteddata['Vehicle.CurrentLocation.HorizontalAccuracy']= result.get('eph')
-                self.collecteddata['Vehicle.CurrentLocation.VerticalAccuracy']= result.get('epv')
+        log.info("gpsd receive loop started")
+        try:
+            for result in self.client.dict_stream(filter=["TPV"]):
+                if self.running:
+                    log.debug("Data received")
+                    collecteddata = {}
+                    collecteddata['Vehicle.CurrentLocation.Latitude'] = result.get('lat')
+                    collecteddata['Vehicle.CurrentLocation.Longitude'] = result.get('lon')
+                    collecteddata['Vehicle.CurrentLocation.Altitude'] = result.get('alt')
+                    collecteddata['Vehicle.Speed'] = result.get('speed')
+                    collecteddata['Vehicle.CurrentLocation.Timestamp'] = result.get('time')
+                    collecteddata['Vehicle.CurrentLocation.Heading'] = result.get('track')
+                    collecteddata['Vehicle.CurrentLocation.HorizontalAccuracy'] = result.get('eph')
+                    collecteddata['Vehicle.CurrentLocation.VerticalAccuracy'] = result.get('epv')
 
-                self.consumer.setData(self.collecteddata)
-                time.sleep(self.interval)
-            else:
-                print("Exiting")
-                break
+                    self.consumer.setData(collecteddata)
+                    time.sleep(self.interval)
+                else:
+                    log.info("Exiting")
+                    break
+        except Exception:
+            log.error("Exception listening to gpsd", exc_info=True)
 
     def shutdown(self):
         self.running = False
         self.consumer.shutdown()
-        print("KUKSA client shutdown")
+        log.info("KUKSA client shutdown")
         self.client.close()
-        print("GPSD client shutdown")
+        log.info("GPSD client shutdown")
         self.join(1)
         if not self.is_alive():
-            print("Shutdown completed")
+            log.info("Shutdown completed")
         else:
-            print("Shutdown join timed out!")
+            log.info("Shutdown join timed out!")
 
 
 if __name__ == "__main__":
+
+    # Example
+    # Set log level to debug
+    #   LOG_LEVEL=debug ./dbcfeeder.py
+    #
+    # Set log level to INFO, but for kuksa_client set it to DEBUG
+    #   LOG_LEVEL=info,kuksa_client=debug ./dbcfeeder.py
+    #
+    # Other available loggers:
+    #   gpsfeeder (main gpsfeeder file)
+    #   kuksa_client (If you want to get additional information from kuksa-client python library)
+    #
+
+    loglevels = parse_env_log(os.environ.get("LOG_LEVEL"))
+
+    # set root loglevel etc
+    init_logging(loglevels["root"])
+
+    # set loglevels for other loggers
+    for logger, level in loglevels.items():
+        if logger != "root":
+            logging.getLogger(logger).setLevel(level)
+
     manual_config = argparse.ArgumentParser()
-    manual_config.add_argument("--host", help="Specify the host where too look for KUKSA.val server/databroker; default: 127.0.0.1", nargs='?' , default="127.0.0.1")
-    manual_config.add_argument("--port", help="Specify the port where too look for KUKSA.val server/databroker; default: 8090", nargs='?' , default="8090")
-    manual_config.add_argument("--protocol", help="If you want to connect to KUKSA.val server specify ws. If you want to connect to KUKSA.val databroker specify grpc; default: ws", nargs='?' , default="ws")
-    manual_config.add_argument("--insecure", help="For KUKSA.val server specify False, for KUKSA.val databroker there is currently no security so specify True; default: False", nargs='?' , default="False")
-    manual_config.add_argument("--certificate", help="Specify the path to your Client.pem file; default: Client.pem", nargs='?' , default="Client.pem")
-    manual_config.add_argument("--cacertificate", help="Specify the path to your CA.pem; default: CA.pem", nargs='?' , default="CA.pem")
-    manual_config.add_argument("--token", help="Specify the path to your JWT token; default: all-read-write.json", nargs='?' , default="all-read-write.json")
-    manual_config.add_argument("--file", help="Specify the path to your config file; default: config/gpsd_feeder.ini", nargs='?' , default="config/gpsd_feeder.ini")
-    manual_config.add_argument("--gpsd_host", help="Specify the host for gpsd to start on; default: 127.0.0.1", nargs='?' , default="127.0.0.1")
-    manual_config.add_argument("--gpsd_port", help="Specify the port for gpsd to start on; default: 2948", nargs='?' , default="2948")
-    manual_config.add_argument("--interval", help="Specify the interval time for feeding gps data; default: 1", nargs='?' , default="1")
+    manual_config.add_argument("--host",
+                               help="Specify the host where too look for KUKSA.val server/databroker; "
+                                    "default: 127.0.0.1",
+                               nargs='?', default="127.0.0.1")
+    manual_config.add_argument("--port",
+                               help="Specify the port where too look for KUKSA.val server/databroker; default: 8090",
+                               nargs='?', default="8090")
+    manual_config.add_argument("--protocol",
+                               help="If you want to connect to KUKSA.val server specify ws. "
+                                    "If you want to connect to KUKSA.val databroker specify grpc; default: ws",
+                                    nargs='?', default="ws")
+    manual_config.add_argument("--insecure",
+                               help="For KUKSA.val server specify False, "
+                                    "for KUKSA.val databroker there is currently no security so specify True; "
+                                    "default: False",
+                               nargs='?', default="False")
+    manual_config.add_argument("--certificate",
+                               help="Specify the path to your Client.pem file; default: Client.pem",
+                               nargs='?', default="Client.pem")
+    manual_config.add_argument("--cacertificate",
+                               help="Specify the path to your CA.pem; default: CA.pem",
+                               nargs='?', default="CA.pem")
+    manual_config.add_argument("--token",
+                               help="Specify the JWT token string or the path to your JWT token; default: "
+                                    "authentication information not specified",
+                               nargs='?', default="")
+    manual_config.add_argument("--file",
+                               help="Specify the path to your config file; by default not defined",
+                               nargs='?', default="")
+    manual_config.add_argument("--gpsd_host", help="Specify the host for gpsd to start on; default: 127.0.0.1",
+                               nargs='?', default="127.0.0.1")
+    manual_config.add_argument("--gpsd_port", help="Specify the port for gpsd to start on; default: 2948",
+                               nargs='?', default="2948")
+    manual_config.add_argument("--interval", help="Specify the interval time for feeding gps data; default: 1",
+                               nargs='?', default="1")
     args = manual_config.parse_args()
-    print(args)
+    log.debug(f"Command line args: {args}")
     if os.path.isfile(args.file):
         configfile = args.file
-        print("# Using config from: {}".format(configfile))
+        log.info("# Using config from: {}".format(configfile))
     else:
         config_object = configparser.ConfigParser()
-        print("No configuration file found. Using default values.")
+        log.info("No configuration file found. Using default values.")
         config_object["kuksa_val"] = {
             "host": args.host,
             "port": args.port,
@@ -136,7 +298,7 @@ if __name__ == "__main__":
             "insecure": args.insecure,
             "certificate": args.certificate,
             "cacertificate": args.cacertificate,
-            "token": args.token,
+            "token_or_tokenfile": args.token,
             "file": args.file,
         }
         config_object["gpsd"] = {
@@ -144,8 +306,7 @@ if __name__ == "__main__":
             "host": args.gpsd_host,
             "port": args.gpsd_port,
         }
-        print("\n#<config.ini>:")
-        config_object.write(sys.stdout)
+        log.debug(f"Writing config: {config_object}")
         with open('config.ini', 'w') as conf:
             config_object.write(conf)
         configfile = "config.ini"
@@ -154,14 +315,13 @@ if __name__ == "__main__":
     config.read(configfile)
 
     gpsd_client = GPSDClientThread(config, Kuksa_Client(config))
+    log.info("Using mapping")
     gpsd_client.start()
 
-
     def terminationSignalreceived(signalNumber, frame):
-        print("Received termination signal. Shutting down")
+        log.info("Received termination signal. Shutting down")
         gpsd_client.shutdown()
         os._exit(1)
 
     signal.signal(signal.SIGINT, terminationSignalreceived)
     signal.signal(signal.SIGTERM, terminationSignalreceived)
-

--- a/gps2val/readme.md
+++ b/gps2val/readme.md
@@ -16,30 +16,44 @@ gpsd -N udp://0.0.0.0:29998
 usage: gpsd_feeder.py [-h] [--host [HOST]] [--port [PORT]] [--protocol [PROTOCOL]] [--insecure [INSECURE]] [--certificate [CERTIFICATE]] [--cacertificate [CACERTIFICATE]] [--token [TOKEN]]
                       [--file [FILE]] [--gpsd_host [GPSD_HOST]] [--gpsd_port [GPSD_PORT]] [--interval [INTERVAL]]
 
-options:  
->-h, --help            show this help message and exit  
->--host [HOST]         Specify the host where too look for KUKSA.val server/databroker; default: 127.0.0.1  
->--port [PORT]         Specify the port where too look for KUKSA.val server/databroker; default: 8090  
+options:
+>-h, --help            show this help message and exit
+>--host [HOST]         Specify the host where too look for KUKSA.val server/databroker; default: 127.0.0.1
+>--port [PORT]         Specify the port where too look for KUKSA.val server/databroker; default: 8090
 >--protocol [PROTOCOL]
-                      If you want to connect to KUKSA.val server specify ws. If you want to connect to KUKSA.val databroker specify grpc; default: ws  
+                      If you want to connect to KUKSA.val server specify ws. If you want to connect to KUKSA.val databroker specify grpc; default: ws
 >--insecure [INSECURE]
-                      For KUKSA.val server specify False, for KUKSA.val databroker there is currently no security so specify True; default: False  
+                      For KUKSA.val server specify False, for KUKSA.val databroker there is currently no security so specify True; default: False
 >--certificate [CERTIFICATE]
-                      Specify the path to your Client.pem file; default: Client.pem  
+                      Specify the path to your Client.pem file; default: Client.pem
 >--cacertificate [CACERTIFICATE]
-                      Specify the path to your CA.pem; default: CA.pem  
->--token [TOKEN]       Specify the path to your JWT token; default: all-read-write.json  
->--file [FILE]         Specify the path to your config file; default: config/gpsd_feeder.ini  
+                      Specify the path to your CA.pem; default: CA.pem
+>--token [TOKEN]       Specify the JWT token or the path to your JWT token; default: token information not specified
+>--file [FILE]         Specify the path to your config file; default: not specifed
 >--gpsd_host [GPSD_HOST]
-                      Specify the host for gpsd to start on; default: 127.0.0.1  
+                      Specify the host for gpsd to start on; default: 127.0.0.1
 >--gpsd_port [GPSD_PORT]
-                      Specify the port for gpsd to start on; default: 2948  
+                      Specify the port for gpsd to start on; default: 2948
 >--interval [INTERVAL]
-                      Specify the interval time for feeding gps data; default: 1  
+                      Specify the interval time for feeding gps data; default: 1
+
+A template config file that can be used together with the `--file` option
+exists in [config/gpsd_feeder.ini](config/gpsd_feeder.ini). Note that if `--file` is specified all other options
+are ignored, instead the values in the config file or default values specified by kuksa-client will be used.
 
 ```
 pip install -r requirements.txt
 python gpsd_feeder.py
+```
+
+## Authorization
+
+gpsd_feeder will try to authenticate itself towards the KUKSA.val Server/Databroker if a token is given.
+Note that the KUKSA.val Databroker by default does not require authentication.
+
+An example for authorizing against KUKSA.val Databroker using an example token is shown below.
+```
+python gpsd_feeder.py --protocol grpc --port 55555 --insecure true --token /home/user/kuksa.val/jwt/provide-all.token
 ```
 
 ### Using docker
@@ -114,4 +128,3 @@ sudo systemctl restart apparmor
 ```
 
 and try again
-

--- a/gps2val/requirements.txt
+++ b/gps2val/requirements.txt
@@ -1,2 +1,2 @@
-kuksa-client
+kuksa-client > 0.3
 gpsdclient


### PR DESCRIPTION
Also refactored to use linter and logging.
Parts of this could eventually later be moved to a common place for all Python feeders

Test performed:

- With/without authentication towards server (requiring auth) and broker (with/without auth configured)