### PR TITLE
Align SPDX header for Python files

### DIFF
--- a/csv_provider/provider.py
+++ b/csv_provider/provider.py
@@ -1,3 +1,18 @@
+#! /usr/bin/env python3
+
+########################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License 2.0 which is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+########################################################################
+
 import asyncio
 import csv
 import argparse

--- a/dbc2val/dbcfeederlib/__init__.py
+++ b/dbc2val/dbcfeederlib/__init__.py
@@ -1,0 +1,12 @@
+########################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License 2.0 which is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+########################################################################

--- a/dbc2val/test/__init__.py
+++ b/dbc2val/test/__init__.py
@@ -1,0 +1,12 @@
+########################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License 2.0 which is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+########################################################################

--- a/dds2val/ddsprovider.py
+++ b/dds2val/ddsprovider.py
@@ -1,3 +1,18 @@
+#! /usr/bin/env python3
+
+########################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License 2.0 which is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+########################################################################
+
 import logging
 import os
 import signal

--- a/dds2val/ddsproviderlib/__init__.py
+++ b/dds2val/ddsproviderlib/__init__.py
@@ -1,0 +1,12 @@
+########################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License 2.0 which is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+########################################################################

--- a/dds2val/ddsproviderlib/idls/setup.py
+++ b/dds2val/ddsproviderlib/idls/setup.py
@@ -1,4 +1,15 @@
-# Copyright (c) 2022 Robert Bosch GmbH
+########################################################################
+# Copyright (c) 2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License 2.0 which is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+########################################################################
 
 from setuptools import setup
 

--- a/dds2val/ddsproviderlib/idls/vss/setup.py
+++ b/dds2val/ddsproviderlib/idls/vss/setup.py
@@ -1,3 +1,16 @@
+########################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License 2.0 which is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+########################################################################
+
 import setuptools
 from setuptools import find_packages
 

--- a/dds2val/tests/__init__.py
+++ b/dds2val/tests/__init__.py
@@ -1,0 +1,12 @@
+########################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License 2.0 which is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+########################################################################

--- a/gps2val/gpsd_feeder.py
+++ b/gps2val/gpsd_feeder.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 ########################################################################
 # Copyright (c) 2020-2023 Contributors to the Eclipse Foundation


### PR DESCRIPTION
This is to make sure all our Python files fulfill our current SPDX check

This PR do:

- Adds SPDX to all python files that did not had it before
- Add our generic copyright to those files (without SPDX) that did not had it before. In some cases this means that explicit Bosch copyright is removed
- Adds python3 shebang for all executables. 
- Also making all "top level" python files executable.