### PR TITLE
Refactor dbc2val for bidirectional use

### DIFF
--- a/.github/workflows/kuksa_dbc_feeder.yml
+++ b/.github/workflows/kuksa_dbc_feeder.yml
@@ -117,7 +117,7 @@ jobs:
         pip3 install --no-cache-dir -r requirements.txt -r requirements-dev.txt
         python -m pytest
 
-    - name: Run pylint (but accept errors for now)
+    - name: Run pylint (fail on errors and above)
       run: |
         cd dbc2val
         # First just show, never fail

--- a/dbc2val/CHANGELOG.md
+++ b/dbc2val/CHANGELOG.md
@@ -6,3 +6,8 @@ This file lists important changes to dbc2val
 
 Feeder refactored and new mapping format based on VSS introduced, see [documentation](mapping.md).
 Old mapping format no longer supported.
+
+
+## Support for bidirectional communication (2023-06)
+
+To be described

--- a/dbc2val/Dockerfile
+++ b/dbc2val/Dockerfile
@@ -43,7 +43,7 @@ WORKDIR /dist
 WORKDIR /data
 COPY ./config/* ./config/
 COPY ./mapping/ ./mapping/
-COPY ./*.dbc ./candump*.log ./
+COPY ./*.dbc ./candump*.log ./*.json ./
 
 # Runner stage, to copy in the virtual environment and the app
 FROM alpine:3

--- a/dbc2val/config/dbc_feeder.ini
+++ b/dbc2val/config/dbc_feeder.ini
@@ -44,6 +44,14 @@ tls = False
 # Possibly like below
 # token=../../kuksa.val/kuksa_certificates/jwt/super-admin.json.token
 
+# Definitions on what directions to support.
+# Default is from CAN to KUKSA (dbc2val) only.
+# Note however that a mapping also is required, so if you do not have any val2dbc mapping, then the val2dbc config
+# does not matter
+dbc2val = True
+# Note that to enable val2dbc you must use SocketCAN, you cannot use candumpfile
+val2dbc = False
+
 [can]
 # CAN port, use elmcan to start the elmcan bridge
 port = vcan0
@@ -56,6 +64,12 @@ dbcfile = Model3CAN.dbc
 # candumpfile not specified (commented out) = use SocketCAN (real or virtual provided by linux)
 # candumpfile specified = use internal canplayer (no SocketCAN dependency)
 candumpfile = candump.log
+
+# JSON file containing default values for dbc signals
+# Currently only used in val2dbc mode to populate dbc signals which either has no VSS mapping or where
+# KUKSA.val not yet has a valid value
+# Values (default or actual) must exist for all DBC signals in CAN frames sent.
+dbc_default_file = dbc_default_values.json
 
 [elmcan]
 # Config for CAN port is \"elmcan\"

--- a/dbc2val/dbc_default_values.json
+++ b/dbc2val/dbc_default_values.json
@@ -1,0 +1,22 @@
+{
+  "VCLEFT_frontHandlePWM" : 0,
+  "VCLEFT_frontHandlePulled" : 0,
+  "VCLEFT_frontHandlePulledPersist" : 0,
+  "VCLEFT_frontIntSwitchPressed" : 0,
+  "VCLEFT_frontLatchStatus" : 0,
+  "VCLEFT_frontLatchSwitch" : 0,
+  "VCLEFT_frontRelActuatorSwitch" : 0,
+  "VCLEFT_mirrorDipped" : 0,
+  "VCLEFT_mirrorFoldState" : 0,
+  "VCLEFT_mirrorHeatState" : 2,
+  "VCLEFT_mirrorRecallState" : 0,
+  "VCLEFT_mirrorState" : 0,
+  "VCLEFT_mirrorTiltXPosition" : 0,
+  "VCLEFT_mirrorTiltYPosition" : 0,
+  "VCLEFT_rearHandlePWM" : 0,
+  "VCLEFT_rearHandlePulled" : 0,
+  "VCLEFT_rearIntSwitchPressed" : 0,
+  "VCLEFT_rearLatchStatus" : 0,
+  "VCLEFT_rearLatchSwitch" : 0,
+  "VCLEFT_rearRelActuatorSwitch" : 0
+}

--- a/dbc2val/dbcfeederlib/canclient.py
+++ b/dbc2val/dbcfeederlib/canclient.py
@@ -1,0 +1,48 @@
+########################################################################
+# Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License 2.0 which is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+########################################################################
+
+import logging
+from typing import Optional
+import can
+from dbcfeederlib import canmessage
+
+log = logging.getLogger(__name__)
+
+
+class CANClient:
+    """
+    Wrapper class to hide dependency to CAN package.
+    Reason is to make it simple to replace the CAN package dependency with something else if your KUKSA.val
+    integration cannot interact directly with CAN, but rather interacts with some custom CAN solution/middleware
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.bus = can.interface.Bus(*args, **kwargs)  # pylint: disable=abstract-class-instantiated
+
+    def recv(self, timeout: int = 1) -> Optional[canmessage.CANMessage]:
+        """Wait for message from CAN"""
+        msg = self.bus.recv(timeout)
+        if msg:
+            canmsg = canmessage.CANMessage(msg)
+            return canmsg
+        return None
+
+    def send(self, arbitration_id, data):
+        """Send message to CAN"""
+        msg = can.Message(arbitration_id=arbitration_id, data=data)
+        try:
+            self.bus.send(msg)
+            log.debug(f"Message sent on {self.bus.channel_info}")
+            log.debug(f"Message: {msg}")
+        except can.CanError:
+            log.error("Failed to send message via CAN bus")

--- a/dbc2val/dbcfeederlib/canmessage.py
+++ b/dbc2val/dbcfeederlib/canmessage.py
@@ -1,0 +1,37 @@
+########################################################################
+# Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License 2.0 which is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+########################################################################
+
+import logging
+import can
+
+log = logging.getLogger(__name__)
+
+
+class CANMessage:
+    """
+    Wrapper class to hide dependency to CAN package.
+    Reason is to make it simple to replace the CAN package dependency with something else if your KUKSA.val
+    integration cannot interact directly with CAN, but rather interacts with some custom CAN solution/middleware.
+    This wrapper class represents a https://python-can.readthedocs.io/en/stable/message.html#can.Message
+    """
+
+    def __init__(self, msg: can.Message):
+        self.msg = msg
+
+    def get_arbitration_id(self) -> int:
+        """Get arbitration/frame id of message"""
+        return self.msg.arbitration_id
+
+    def get_data(self):
+        """Get message data"""
+        return self.msg.data

--- a/dbc2val/dbcfeederlib/clientwrapper.py
+++ b/dbc2val/dbcfeederlib/clientwrapper.py
@@ -14,7 +14,7 @@
 #################################################################################
 
 import logging
-from typing import Any
+from typing import Any, List
 
 from abc import ABC, abstractmethod
 
@@ -79,3 +79,11 @@ class ClientWrapper(ABC):
     @abstractmethod
     def stop(self):
         pass
+
+    @abstractmethod
+    def supports_subscription(self) -> bool:
+        """Return true if this client supports subscribing to VSS signals"""
+
+    @abstractmethod
+    async def subscribe(self, vss_names: List[str], callback):
+        """Creates a subscription and calls the callback when data received"""

--- a/dbc2val/dbcfeederlib/dbc2vssmapper.py
+++ b/dbc2val/dbcfeederlib/dbc2vssmapper.py
@@ -26,12 +26,15 @@ as well as transforming dbc data to VSS data.
 import json
 import logging
 import sys
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Set
 from dataclasses import dataclass
 
 from py_expression_eval import Parser
 
+from dbcfeederlib import dbcparser
+
 log = logging.getLogger(__name__)
+
 
 @dataclass
 class VSSObservation:
@@ -41,31 +44,38 @@ class VSSObservation:
     into VSS representation.
     """
 
-    dbc_name : str
-    vss_name : str
-    raw_value : Any
-    time : float
+    dbc_name: str
+    vss_name: str
+    raw_value: Any
+    time: float
 
 
 class VSSMapping:
-    """A mapping for a VSS signal"""
+    """
+    A mapping for a VSS signal.
+    This mapping can be used to represent either dbc2val or val2dbc mapping.
+    As of today just by looking at an instance of this class you cannot say
+    which direction it concerns.
+    """
 
-    parser : Parser = Parser()
+    parser: Parser = Parser()
 
-    def __init__(self, vss_name : str, transform :dict, interval_ms : int,
-                 on_change : bool, datatype: str, description : str):
+    def __init__(self, vss_name: str, dbc_name: str, transform: dict, interval_ms: int,
+                 on_change: bool, datatype: str, description: str):
         self.vss_name = vss_name
+        self.dbc_name = dbc_name
         self.transform = transform
         self.interval_ms = interval_ms
         self.on_change = on_change
         self.datatype = datatype
         self.description = description
         # For time comparison (interval_ms) we store last value used for comparison. Unit seconds.
-        self.last_time : float = 0.0
+        self.last_time: float = 0.0
         # For value comparison (on_changes) we store last value used for comparison
-        self.last_vss_value : Any = None
+        self.last_vss_value: Any = None
+        self.last_dbc_value: Any = None
 
-    def time_condition_fulfilled(self, time : float) -> bool:
+    def time_condition_fulfilled(self, time: float) -> bool:
         """
         Checks if time condition to send signal is fulfilled
         Value (on_change) condition not evaluated
@@ -76,7 +86,7 @@ class VSSMapping:
 
         # First shall always evaluate to true
         if (self.interval_ms > 0) and (self.last_time != 0.0):
-            diff_ms =( time - self.last_time) * 1000.0
+            diff_ms = (time - self.last_time) * 1000.0
             if diff_ms < self.interval_ms:
                 log.debug(f"Interval not exceeded for {self.vss_name}. Time is {time}")
                 fulfilled = False
@@ -88,7 +98,7 @@ class VSSMapping:
 
         return fulfilled
 
-    def change_condition_fulfilled(self, vss_value : Any) -> bool:
+    def change_condition_fulfilled(self, vss_value: Any) -> bool:
         """
         Checks if change condition to send signal is fulfilled.
         Transformation is expected to be costly, so transformation and value check only performed
@@ -98,7 +108,7 @@ class VSSMapping:
         log.debug(f"Checking change condition for {self.vss_name}. "
                   f"New value {vss_value}, old value {self.last_vss_value}")
 
-        if not vss_value is None:
+        if vss_value is not None:
             if self.last_vss_value is None:
                 # Always send first value
                 fulfilled = True
@@ -111,9 +121,7 @@ class VSSMapping:
             self.last_vss_value = vss_value
         return fulfilled
 
-
-
-    def transform_value(self, value : Any) -> Any:
+    def transform_value(self, value: Any) -> Any:
         """
         Transforms the given "raw" DBC value to the wanted VSS value.
         For now does not make any type checks
@@ -162,25 +170,50 @@ class Mapper:
     """
 
     # Where we keep mapping, key is dbc signal name
-    mapping : Dict[str, List[VSSMapping]] = {}
+    dbc2val_mapping: Dict[str, List[VSSMapping]] = {}
+    # In this direction key is VSS name
+    val2dbc_mapping: Dict[str, List[VSSMapping]] = {}
+    # Same, but key is CAN id mapping
+    val2dbc_can_id_mapping: Dict[int, List[VSSMapping]] = {}
 
-    def transform_value(self, vss_observation : VSSObservation) -> Any:
+    def __init__(self, filename, dbc_parser: dbcparser.DBCParser, dbc_default_filename=""):
+        with open(filename, "r") as file:
+            try:
+                jsonmapping = json.load(file)
+                log.info(f"Reading dbc configurations from {filename}")
+            except Exception:
+                log.error(f"Failed to read json from {filename}", exc_info=True)
+                sys.exit(-1)
+
+        self.dbc_default = {}
+        if dbc_default_filename != "":
+            log.info(f"Reading default DBC values from {dbc_default_filename}")
+            with open(dbc_default_filename, "r") as file:
+                try:
+                    self.dbc_default = json.load(file)
+                except Exception:
+                    log.error(f"Failed to read DBC values from {dbc_default_filename}", exc_info=True)
+                    sys.exit(-1)
+        self.dbc_parser = dbc_parser
+        self.traverse_vss_node("", jsonmapping)
+
+    def transform_dbc_value(self, vss_observation: VSSObservation) -> Any:
         """
-        Find mapping and transform value.
+        Find VSS mapping and transform DBC value to VSS value.
         """
         # If we have an observation we know that a mapping exists
-        vss_signal = self.get_vss_mapping(vss_observation.dbc_name, vss_observation.vss_name)
+        vss_signal = self.get_dbc2val_mapping(vss_observation.dbc_name, vss_observation.vss_name)
         value = vss_signal.transform_value(vss_observation.raw_value)
         log.debug(f"Transformed dbc {vss_observation.dbc_name} to VSS "
                   f"{vss_observation.vss_name}, "
                   f"from raw value {vss_observation.raw_value} to {value}")
         return value
 
-    def extract_verify_transform(self, expanded_name : str , node : dict):
+    def extract_verify_transform(self, expanded_name: str, node: dict):
         """
         Extracts transformation and checks it seems to be correct
         """
-        if not "transform" in node:
+        if "transform" not in node:
             log.debug(f"No transformation found for {expanded_name}")
             # For now assumed that None is Ok
             return None
@@ -214,46 +247,93 @@ class Mapper:
             sys.exit(-1)
         return transform
 
+    def analyze_dbc2val(self, expanded_name, node: dict, dbc2vss: dict):
+        """
+        Analyze a dbc2val entry (from CAN to KUKSA)
+        """
+
+        transform = self.extract_verify_transform(expanded_name, dbc2vss)
+        dbc_name = dbc2vss.get("signal", "")
+        if dbc_name == "":
+            log.error(f"No dbc signal found for {expanded_name}")
+            sys.exit(-1)
+        on_change: bool = False
+        if "on_change" in dbc2vss:
+            tmp = dbc2vss["on_change"]
+            if isinstance(tmp, bool):
+                on_change = tmp
+            else:
+                log.error(f"Value for on_change ({tmp}) is not bool")
+                sys.exit(-1)
+        if "interval_ms" in dbc2vss:
+            interval = dbc2vss["interval_ms"]
+            if not isinstance(interval, int):
+                log.error(f"Faulty interval for {expanded_name}")
+                sys.exit(-1)
+        else:
+            if on_change:
+                log.info(f"Using default interval 0 ms for {expanded_name} "
+                         f"as it has on_change condition")
+                interval = 0
+            else:
+                log.info(f"Using default interval 1000 ms for {expanded_name}")
+                interval = 1000
+        mapping_entry = VSSMapping(expanded_name, dbc_name, transform, interval, on_change,
+                                   node["datatype"], node["description"])
+        if dbc_name not in self.dbc2val_mapping:
+            self.dbc2val_mapping[dbc_name] = []
+        self.dbc2val_mapping[dbc_name].append(mapping_entry)
+
+    def analyze_val2dbc(self, expanded_name, node: dict, vss2dbc: dict):
+        """
+        Analyze a dbc2val entry (from CAN to KUKSA)
+        """
+
+        transform = self.extract_verify_transform(expanded_name, vss2dbc)
+        dbc_name = vss2dbc.get("signal", "")
+        if dbc_name == "":
+            log.error(f"No dbc signal found for {expanded_name}")
+            sys.exit(-1)
+        # For now we only support on_change, and we actually do not use the values
+        on_change: bool = True
+        interval = 0
+        if "on_change" in vss2dbc:
+            log.warning(f"on_change attribute ignored for {expanded_name}")
+        if "interval_ms" in vss2dbc:
+            log.warning(f"interval_ms attribute ignored for {expanded_name}")
+
+        mapping_entry = VSSMapping(expanded_name, dbc_name, transform, interval, on_change,
+                                   node["datatype"], node["description"])
+        if dbc_name not in self.val2dbc_mapping:
+            self.val2dbc_mapping[expanded_name] = []
+        self.val2dbc_mapping[expanded_name].append(mapping_entry)
+
+        # Also add CAN-id
+        dbc_can_id = self.dbc_parser.get_canid_for_signal(dbc_name)
+        if dbc_can_id not in self.val2dbc_can_id_mapping:
+            self.val2dbc_can_id_mapping[dbc_can_id] = []
+        self.val2dbc_can_id_mapping[dbc_can_id].append(mapping_entry)
+
     def analyze_signal(self, expanded_name, node):
         """
         Analyzes a signal and add mapping entry if correct mapping found
         """
+        dbc2vss_def = None
         if "dbc" in node:
             log.debug(f"Signal {expanded_name} has dbc!")
-            dbc_def = node["dbc"]
-            transform = self.extract_verify_transform(expanded_name, dbc_def)
-            dbc_name = dbc_def.get("signal", "")
-            if dbc_name == "":
-                log.error(f"No dbc signal found for {expanded_name}")
+            dbc2vss_def = node["dbc"]
+            if "dbc2vss" in node:
+                log.error(f"Node {expanded_name} has both dbc and dbc2vss")
                 sys.exit(-1)
-            on_change : bool = False
-            if "on_change" in dbc_def:
-                tmp = dbc_def["on_change"]
-                if isinstance(tmp,bool):
-                    on_change = tmp
-                else:
-                    log.error(f"Value for on_change ({tmp}) is not bool")
-                    sys.exit(-1)
-            if "interval_ms" in dbc_def:
-                interval = dbc_def["interval_ms"]
-                if not isinstance(interval,int):
-                    log.error(f"Faulty interval for {expanded_name}")
-                    sys.exit(-1)
-            else:
-                if on_change:
-                    log.info(f"Using default interval 0 ms for {expanded_name} "
-                             f"as it has on_change condition")
-                    interval = 0
-                else:
-                    log.info(f"Using default interval 1000 ms for {expanded_name}")
-                    interval = 1000
-            mapping_entry = VSSMapping(expanded_name, transform, interval, on_change,
-                                       node["datatype"], node["description"])
-            if not dbc_name in self.mapping:
-                self.mapping[dbc_name] = []
-            self.mapping[dbc_name].append(mapping_entry)
+        elif "dbc2vss" in node:
+            log.debug(f"Signal {expanded_name} has dbc2vss!")
+            dbc2vss_def = node["dbc2vss"]
+        if dbc2vss_def is not None:
+            self.analyze_dbc2val(expanded_name, node, dbc2vss_def)
+        if "vss2dbc" in node:
+            self.analyze_val2dbc(expanded_name, node, node["vss2dbc"])
 
-    def traverse_vss_node(self,name, node, prefix = ""):
+    def traverse_vss_node(self, name, node, prefix=""):
         """
         Traverse a vss node/tree and order all found VSS signals to be analyzed
         so that mapping can be extracted
@@ -261,9 +341,9 @@ class Mapper:
         is_signal = False
         is_branch = False
         expanded_name = ""
-        if isinstance(node,dict):
+        if isinstance(node, dict):
             if "type" in node:
-                if node["type"] in ["sensor","actuator", "attribute"]:
+                if node["type"] in ["sensor", "actuator", "attribute"]:
                     is_signal = True
                 elif node["type"] in ["branch"]:
                     is_branch = True
@@ -272,44 +352,85 @@ class Mapper:
         # Assuming it to be a dict
         if is_branch:
             for item in node["children"].items():
-                self.traverse_vss_node(item[0],item[1],prefix)
+                self.traverse_vss_node(item[0], item[1], prefix)
         elif is_signal:
             expanded_name = prefix + name
             self.analyze_signal(expanded_name, node)
-        elif isinstance(node,dict):
+        elif isinstance(node, dict):
             for item in node.items():
-                self.traverse_vss_node(item[0],item[1],prefix)
+                self.traverse_vss_node(item[0], item[1], prefix)
 
-    def get_vss_mapping(self, dbc_name : str, vss_name :str) -> VSSMapping:
+    def get_dbc2val_mapping(self, dbc_name: str, vss_name: str) -> VSSMapping:
         """
         Helper method for test purposes
         """
-        if dbc_name in self.mapping:
-            for mapping in self.mapping[dbc_name]:
+        if dbc_name in self.dbc2val_mapping:
+            for mapping in self.dbc2val_mapping[dbc_name]:
                 if mapping.vss_name == vss_name:
                     return mapping
         return None
 
+    def get_dbc2val_entries(self) -> Set[str]:
+        """Return a set of all dbc names used for reception"""
+        return self.dbc2val_mapping.keys()
 
-    def __init__(self, filename):
-        with open(filename, "r") as file:
-            try:
-                jsonmapping = json.load(file)
-                log.info(f"Reading dbc configurations from {filename}")
-            except Exception:
-                log.error(f"Failed to read json from {filename}", exc_info=True)
-                sys.exit(-1)
+    def get_val2dbc_entries(self) -> Set[str]:
+        """Return a set of all vss names used for reception"""
+        return self.val2dbc_mapping.keys()
 
-        self.traverse_vss_node("",jsonmapping)
+    def get_vss_names(self) -> Set[str]:
+        """Get all VSS names used in mappings, both vss2dbc and dbc2vss"""
+        vss_names = set()
+        for entry in self.dbc2val_mapping.values():
+            for vss_mapping in entry:
+                vss_names.add(vss_mapping.vss_name)
+        for entry in self.val2dbc_mapping.keys():
+            vss_names.add(entry)
+        return vss_names
 
+    def has_dbc2val_mapping(self) -> bool:
+        return bool(self.dbc2val_mapping)
 
-    def map(self):
-        """ Get access to the map items """
-        return self.mapping.items()
+    def has_val2dbc_mapping(self) -> bool:
+        return bool(self.val2dbc_mapping)
 
-    def __contains__(self, key):
-        return key in self.mapping
+    def get_dbc2val_mappings(self, dbc_name: str) -> List[VSSMapping]:
+        if dbc_name in self.dbc2val_mapping:
+            return self.dbc2val_mapping[dbc_name]
+        return []
 
-    def __getitem__(self, item):
-        return self.mapping[item]
-    
+    def handle_update(self, vss_name, value: Any) -> Set[str]:
+        """
+        Finds dbc signals using this VSS-signal, transform value accordingly
+        and updated stored value.
+        Returns set of affected CAN signal identifiers.
+        Types of values tested so far: int, bool
+        """
+        dbc_ids = set()
+        # Theoretically there might me multiple DBC-signals served by this VSS-signal
+        for dbc_mapping in self.val2dbc_mapping[vss_name]:
+
+            dbc_value = dbc_mapping.transform_value(value)
+            dbc_mapping.last_dbc_value = dbc_value
+            dbc_ids.add(dbc_mapping.dbc_name)
+        return dbc_ids
+
+    def get_default_values(self, can_id) -> Dict[int, Any]:
+
+        res = {}
+        for signal in self.dbc_parser.get_signals_for_canid(can_id):
+            if signal in self.dbc_default:
+                res[signal] = self.dbc_default[signal]
+            else:
+                log.error(f"No default value for  {signal} in CAN id {can_id}")
+        return res
+
+    def get_value_dict(self, can_id):
+
+        log.debug(f"Using stored information to create CAN-frame for {can_id}")
+        res = self.get_default_values(can_id)
+        for can_mapping in self.val2dbc_can_id_mapping[can_id]:
+            log.debug(f"Using DBC id {can_mapping.dbc_name} with value {can_mapping.last_dbc_value}")
+            if can_mapping.last_dbc_value is not None:
+                res[can_mapping.dbc_name] = can_mapping.last_dbc_value
+        return res

--- a/dbc2val/dbcfeederlib/dbcparser.py
+++ b/dbc2val/dbcfeederlib/dbcparser.py
@@ -1,0 +1,72 @@
+#!/usr/bin/python3
+
+########################################################################
+# Copyright (c) 2023 Robert Bosch GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+########################################################################
+
+import logging
+from typing import Set, Optional, Dict
+import cantools
+
+log = logging.getLogger(__name__)
+
+
+class DBCParser:
+    def __init__(self, dbcfile: str, use_strict_parsing: bool = True):
+
+        # Read DBC file
+        log.info("Reading DBC file {}".format(dbcfile))
+        self.db = cantools.database.load_file(dbcfile, strict=use_strict_parsing)
+
+        # Init some dictionaries to speed up search
+        self.signal_to_canid: Dict[str, Optional[int]] = {}
+        self.canid_to_signals: Dict[int, Set[str]] = {}
+
+    def get_canid_for_signal(self, sig_to_find: str) -> Optional[int]:
+        if sig_to_find in self.signal_to_canid:
+            return self.signal_to_canid[sig_to_find]
+
+        for msg in self.db.messages:
+            for signal in msg.signals:
+                if signal.name == sig_to_find:
+                    frame_id = msg.frame_id
+                    log.info(
+                        "Found signal in DBC file {} in CAN frame id 0x{:02x}".format(
+                            signal.name, frame_id
+                        )
+                    )
+                    self.signal_to_canid[sig_to_find] = frame_id
+                    return frame_id
+        log.warning("Signal {} not found in DBC file".format(sig_to_find))
+        self.signal_to_canid[sig_to_find] = None
+        return None
+
+    def get_signals_for_canid(self, canid: int) -> Set[str]:
+
+        if canid in self.canid_to_signals:
+            return self.canid_to_signals[canid]
+
+        for msg in self.db.messages:
+            if canid == msg.frame_id:
+                names = set()
+                for signal in msg.signals:
+                    names.add(signal.name)
+                self.canid_to_signals[canid] = names
+                return names
+        log.warning(f"CAN id {canid} not found in DBC file")
+        self.canid_to_signals[canid] = []
+        return []

--- a/dbc2val/dbcfeederlib/j1939reader.py
+++ b/dbc2val/dbcfeederlib/j1939reader.py
@@ -26,7 +26,6 @@
 import logging
 import time
 
-import cantools
 import j1939
 from dbcfeederlib import dbc2vssmapper
 from queue import Queue
@@ -36,11 +35,11 @@ log = logging.getLogger(__name__)
 
 class J1939Reader:
 
-    def __init__(self, rxqueue: Queue, dbcfile: str, mapper: str, use_strict_parsing: bool):
+    def __init__(self, rxqueue: Queue, mapper, dbc_parser):
         self.queue = rxqueue
-        self.db = cantools.database.load_file(dbcfile, strict = use_strict_parsing)
         self.mapper = mapper
-        self.ecu = j1939.ElectronicControlUnit();
+        self.dbc_parser = dbc_parser
+        self.ecu = j1939.ElectronicControlUnit()
 
     def stop(self):
         self.ecu.disconnect()
@@ -90,7 +89,7 @@ class J1939Reader:
 
     def identify_message(self, pgn):
         pgn_hex = hex(pgn)[2:]  # only hex(pgn) without '0x' prefix
-        for message in self.db.messages:
+        for message in self.dbc_parser.db.messages:
             message_hex = hex(message.frame_id)[
                 -6:-2
             ]  # only hex(pgn) without '0x' prefix, priority and source address

--- a/dbc2val/dbcfeederlib/serverclientwrapper.py
+++ b/dbc2val/dbcfeederlib/serverclientwrapper.py
@@ -14,13 +14,12 @@
 #################################################################################
 
 import logging
-from typing import Any
+from typing import Any, List
 import json
 
-from dbcfeederlib import clientwrapper
-
-
 from kuksa_client import KuksaClientThread
+
+from dbcfeederlib import clientwrapper
 
 log = logging.getLogger(__name__)
 
@@ -71,15 +70,15 @@ class ServerClientWrapper(clientwrapper.ClientWrapper):
     def is_connected(self) -> bool:
         # This one is quite unreliable, see https://github.com/eclipse/kuksa.val/issues/523
         if self._kuksa is None:
-            log.warning("is_connected called before client has been started")
+            log.error("is_connected called before client has been started")
             return False
         return self._kuksa.checkConnection()
 
     def is_signal_defined(self, vss_name: str) -> bool:
         if self._kuksa is None:
-            log.warning("is_signal_defined called before client has been started")
+            log.error("is_signal_defined called before client has been started")
             return False
-        """Check if signal is defined in server """
+        # Check if signal is defined in server
         resp = json.loads(self._kuksa.getMetaData(vss_name))
         if "error" in resp:
             log.error(f"Signal {vss_name} appears not to be registered: {resp['error']}")
@@ -95,7 +94,7 @@ class ServerClientWrapper(clientwrapper.ClientWrapper):
         (possibly with correct case)
         """
         if self._kuksa is None:
-            log.warning("update_datapoint called before client has been started")
+            log.error("update_datapoint called before client has been started")
             return False
         success = True
         if isinstance(value, bool):
@@ -117,3 +116,11 @@ class ServerClientWrapper(clientwrapper.ClientWrapper):
         if self._kuksa is not None:
             self._kuksa.stop()
             self._kuksa = None
+
+    def supports_subscription(self) -> bool:
+        log.info("Feature not implemented")
+        return False
+
+    async def subscribe(self, vss_names: List[str], callback):
+        log.error("Feature not implemented")
+        return

--- a/dbc2val/mapping/vss_4.0/dbc_overlay.vspec
+++ b/dbc2val/mapping/vss_4.0/dbc_overlay.vspec
@@ -29,7 +29,7 @@
 Vehicle.Chassis.SteeringWheel.Angle:
   datatype: int16
   type: sensor
-  dbc:
+  dbc2vss:
     signal: SteeringAngle129
     interval_ms: 100
     transform:
@@ -38,21 +38,21 @@ Vehicle.Chassis.SteeringWheel.Angle:
 Vehicle.Speed:
   type: sensor
   datatype: float
-  dbc:
+  dbc2vss:
     signal: DI_uiSpeed
     interval_ms: 100
 
 Vehicle.OBD.Speed:
   type: sensor
   datatype: float
-  dbc:
+  dbc2vss:
     signal: DI_uiSpeed
     interval_ms: 100
 
 Vehicle.Powertrain.Transmission.CurrentGear:
   type: sensor
   datatype: int8
-  dbc:
+  dbc2vss:
     interval_ms: 100
     signal: DI_gear
     transform:
@@ -69,7 +69,7 @@ Vehicle.Powertrain.Transmission.CurrentGear:
 Vehicle.Powertrain.Transmission.IsParkLockEngaged:
   type: sensor
   datatype: boolean
-  dbc:
+  dbc2vss:
     interval_ms: 100
     signal: DI_gear
     transform:
@@ -86,21 +86,21 @@ Vehicle.Powertrain.Transmission.IsParkLockEngaged:
 Vehicle.Powertrain.ElectricMotor.Torque:
   type: sensor
   datatype: int16
-  dbc:
+  dbc2vss:
     interval_ms: 100
     signal: DIR_torqueActual
 
 Vehicle.OBD.ControlModuleVoltage:
   type: sensor
   datatype: float
-  dbc:
+  dbc2vss:
     interval_ms: 1000
     signal: PCS_dcdcLvBusVolt
 
 Vehicle.Powertrain.TractionBattery.Charging.IsCharging:
   type: sensor
   datatype: boolean
-  dbc:
+  dbc2vss:
     interval_ms: 1000
     signal: CP_hvChargeStatus
     transform:
@@ -123,7 +123,7 @@ Vehicle.Powertrain.TractionBattery.Charging.IsCharging:
 Vehicle.Chassis.Axle.Row1.Wheel.Left.Brake.IsFluidLevelLow:
   type: sensor
   datatype: boolean
-  dbc:
+  dbc2vss:
     interval_ms: 1000
     signal: VCFRONT_brakeFluidLevel
     transform:
@@ -136,7 +136,7 @@ Vehicle.Chassis.Axle.Row1.Wheel.Left.Brake.IsFluidLevelLow:
 Vehicle.Chassis.Axle.Row1.Wheel.Right.Brake.IsFluidLevelLow:
   type: sensor
   datatype: boolean
-  dbc:
+  dbc2vss:
     interval_ms: 1000
     signal: VCFRONT_brakeFluidLevel
     transform:
@@ -149,7 +149,7 @@ Vehicle.Chassis.Axle.Row1.Wheel.Right.Brake.IsFluidLevelLow:
 Vehicle.Chassis.Axle.Row2.Wheel.Left.Brake.IsFluidLevelLow:
   type: sensor
   datatype: boolean
-  dbc:
+  dbc2vss:
     interval_ms: 1000
     signal: VCFRONT_brakeFluidLevel
     transform:
@@ -162,7 +162,7 @@ Vehicle.Chassis.Axle.Row2.Wheel.Left.Brake.IsFluidLevelLow:
 Vehicle.Chassis.Axle.Row2.Wheel.Right.Brake.IsFluidLevelLow:
   type: sensor
   datatype: boolean
-  dbc:
+  dbc2vss:
     interval_ms: 1000
     signal: VCFRONT_brakeFluidLevel
     transform:
@@ -175,14 +175,14 @@ Vehicle.Chassis.Axle.Row2.Wheel.Right.Brake.IsFluidLevelLow:
 Vehicle.OBD.AmbientAirTemperature:
   type: sensor
   datatype: float
-  dbc:
+  dbc2vss:
     interval_ms: 1000
     signal: VCFRONT_tempAmbientFiltered
 
 Vehicle.Body.Windshield.Front.WasherFluid.IsLevelLow:
   type: sensor
   datatype: boolean
-  dbc:
+  dbc2vss:
     interval_ms: 1000
     signal: VCFRONT_washerFluidLevel
     transform:
@@ -199,7 +199,7 @@ Vehicle.Body.Windshield.Front.WasherFluid.IsLevelLow:
 Vehicle.Body.Mirrors.DriverSide.IsHeatingOn:
   type: actuator
   datatype: boolean
-  dbc:
+  dbc2vss:
     interval_ms: 1000
     signal: VCLEFT_mirrorHeatState
     transform:
@@ -212,7 +212,7 @@ Vehicle.Body.Mirrors.DriverSide.IsHeatingOn:
 Vehicle.Body.Mirrors.PassengerSide.IsHeatingOn:
   type: actuator
   datatype: boolean
-  dbc:
+  dbc2vss:
     interval_ms: 1000
     signal: VCLEFT_mirrorHeatState
     transform:
@@ -225,25 +225,33 @@ Vehicle.Body.Mirrors.PassengerSide.IsHeatingOn:
 Vehicle.Body.Mirrors.DriverSide.Tilt:
   datatype: int8
   type: actuator
-  dbc:
+  dbc2vss:
     signal: VCLEFT_mirrorTiltYPosition
     interval_ms: 100
     transform:
       math: "floor((x*40)-100)"
+  vss2dbc:
+    signal: VCLEFT_mirrorTiltYPosition
+    transform:
+      math: "(x+100)/40"
 
 Vehicle.Body.Mirrors.DriverSide.Pan:
   datatype: int8
   type: actuator
-  dbc:
+  dbc2vss:
     signal: VCLEFT_mirrorTiltXPosition
     interval_ms: 100
     transform:
       math: "floor((x*40)-100)"
+  vss2dbc:
+    signal: VCLEFT_mirrorTiltXPosition
+    transform:
+      math: "(x+100)/40"
 
 Vehicle.Body.Mirrors.PassengerSide.Tilt:
   datatype: int8
   type: actuator
-  dbc:
+  dbc2vss:
     signal: VCRIGHT_mirrorTiltYPosition
     interval_ms: 100
     transform:
@@ -252,7 +260,7 @@ Vehicle.Body.Mirrors.PassengerSide.Tilt:
 Vehicle.Body.Mirrors.PassengerSide.Pan:
   datatype: int8
   type: actuator
-  dbc:
+  dbc2vss:
     signal: VCRIGHT_mirrorTiltXPosition
     interval_ms: 100
     transform:
@@ -261,7 +269,7 @@ Vehicle.Body.Mirrors.PassengerSide.Pan:
 Vehicle.Body.Trunk.Rear.IsOpen:
   type: actuator
   datatype: boolean
-  dbc:
+  dbc2vss:
     interval_ms: 1000
     signal: VCRIGHT_trunkLatchStatus
     transform:
@@ -278,18 +286,28 @@ Vehicle.Body.Trunk.Rear.IsOpen:
           to: true
         - from: LATCH_OPENING
           to: true
+  vss2dbc:
+    signal: VCRIGHT_trunkLatchStatus
+    transform:
+       mapping:
+        - from: true
+          to: LATCH_OPENED
+        - from: false
+          to: LATCH_CLOSED
 
 Vehicle.Powertrain.ElectricMotor.Temperature:
   datatype: int16
   type: sensor
-  dbc:
+  dbc2vss:
     signal: PTC_rightTempIGBT
     interval_ms: 1000
+  vss2dbc:
+    signal: PTC_rightTempIGBT
 
 Vehicle.Cabin.Door.Row1.DriverSide.IsOpen:
   type: actuator
   datatype: boolean
-  dbc:
+  dbc2vss:
     interval_ms: 500
     signal: VCLEFT_frontDoorState
     transform:
@@ -304,7 +322,7 @@ Vehicle.Cabin.Door.Row1.DriverSide.IsOpen:
 Vehicle.Cabin.Door.Row2.DriverSide.IsOpen:
   type: actuator
   datatype: boolean
-  dbc:
+  dbc2vss:
     interval_ms: 500
     signal: VCLEFT_rearDoorState
     transform:
@@ -319,7 +337,7 @@ Vehicle.Cabin.Door.Row2.DriverSide.IsOpen:
 Vehicle.Cabin.Seat.Row1.DriverSide.IsBelted:
   type: sensor
   datatype: boolean
-  dbc:
+  dbc2vss:
     interval_ms: 1000
     signal: VCFRONT_driverBuckleStatus
     transform:
@@ -332,7 +350,7 @@ Vehicle.Cabin.Seat.Row1.DriverSide.IsBelted:
 Vehicle.Body.Lights.Brake.IsActive:
   type: actuator
   datatype: string
-  dbc:
+  dbc2vss:
     interval_ms: 100
     signal: VCRIGHT_brakeLightStatus
     transform:
@@ -349,7 +367,7 @@ Vehicle.Body.Lights.Brake.IsActive:
 Vehicle.Body.Lights.Fog.Rear.IsOn:
   type: actuator
   datatype: boolean
-  dbc:
+  dbc2vss:
     interval_ms: 100
     signal: VCRIGHT_brakeLightStatus
     transform:
@@ -366,7 +384,7 @@ Vehicle.Body.Lights.Fog.Rear.IsOn:
 Vehicle.Body.Lights.Backup.IsOn:
   type: actuator
   datatype: boolean
-  dbc:
+  dbc2vss:
     interval_ms: 100
     signal: VCRIGHT_reverseLightStatus
     transform:
@@ -383,7 +401,7 @@ Vehicle.Body.Lights.Backup.IsOn:
 Vehicle.Body.Lights.DirectionIndicator.Right.IsSignaling:
   type: actuator
   datatype: boolean
-  dbc:
+  dbc2vss:
     interval_ms: 100
     signal: VCRIGHT_turnSignalStatus
     transform:
@@ -400,7 +418,7 @@ Vehicle.Body.Lights.DirectionIndicator.Right.IsSignaling:
 Vehicle.Body.Lights.DirectionIndicator.Left.IsSignaling:
   type: actuator
   datatype: boolean
-  dbc:
+  dbc2vss:
     interval_ms: 100
     signal: VCLEFT_turnSignalStatus
     transform:
@@ -417,7 +435,7 @@ Vehicle.Body.Lights.DirectionIndicator.Left.IsSignaling:
 Vehicle.Trailer.IsConnected:
   type: sensor
   datatype: boolean
-  dbc:
+  dbc2vss:
     interval_ms: 3000
     signal: VCLEFT_trailerDetected
     transform:
@@ -434,7 +452,7 @@ Vehicle.Trailer.IsConnected:
 Vehicle.OBD.EngineLoad:
   type: sensor
   datatype: float
-  dbc:
+  dbc2vss:
     signal: RearPower266
     interval_ms: 100
     transform:

--- a/dbc2val/mapping/vss_4.0/vss_dbc.json
+++ b/dbc2val/mapping/vss_4.0/vss_dbc.json
@@ -370,7 +370,7 @@
                   },
                   "IsOn": {
                     "datatype": "boolean",
-                    "dbc": {
+                    "dbc2vss": {
                       "interval_ms": 100,
                       "signal": "VCRIGHT_reverseLightStatus",
                       "transform": {
@@ -448,7 +448,7 @@
                       "ADAPTIVE"
                     ],
                     "datatype": "string",
-                    "dbc": {
+                    "dbc2vss": {
                       "interval_ms": 100,
                       "signal": "VCRIGHT_brakeLightStatus",
                       "transform": {
@@ -495,7 +495,7 @@
                       },
                       "IsSignaling": {
                         "datatype": "boolean",
-                        "dbc": {
+                        "dbc2vss": {
                           "interval_ms": 100,
                           "signal": "VCLEFT_turnSignalStatus",
                           "transform": {
@@ -535,7 +535,7 @@
                       },
                       "IsSignaling": {
                         "datatype": "boolean",
-                        "dbc": {
+                        "dbc2vss": {
                           "interval_ms": 100,
                           "signal": "VCRIGHT_turnSignalStatus",
                           "transform": {
@@ -597,7 +597,7 @@
                       },
                       "IsOn": {
                         "datatype": "boolean",
-                        "dbc": {
+                        "dbc2vss": {
                           "interval_ms": 100,
                           "signal": "VCRIGHT_brakeLightStatus",
                           "transform": {
@@ -725,7 +725,7 @@
                 "children": {
                   "IsHeatingOn": {
                     "datatype": "boolean",
-                    "dbc": {
+                    "dbc2vss": {
                       "interval_ms": 1000,
                       "signal": "VCLEFT_mirrorHeatState",
                       "transform": {
@@ -746,7 +746,7 @@
                   },
                   "Pan": {
                     "datatype": "int8",
-                    "dbc": {
+                    "dbc2vss": {
                       "interval_ms": 100,
                       "signal": "VCLEFT_mirrorTiltXPosition",
                       "transform": {
@@ -757,11 +757,17 @@
                     "max": 100,
                     "min": -100,
                     "type": "actuator",
-                    "unit": "percent"
+                    "unit": "percent",
+                    "vss2dbc": {
+                      "signal": "VCLEFT_mirrorTiltXPosition",
+                      "transform": {
+                        "math": "(x+100)/40"
+                      }
+                    }
                   },
                   "Tilt": {
                     "datatype": "int8",
-                    "dbc": {
+                    "dbc2vss": {
                       "interval_ms": 100,
                       "signal": "VCLEFT_mirrorTiltYPosition",
                       "transform": {
@@ -772,7 +778,13 @@
                     "max": 100,
                     "min": -100,
                     "type": "actuator",
-                    "unit": "percent"
+                    "unit": "percent",
+                    "vss2dbc": {
+                      "signal": "VCLEFT_mirrorTiltYPosition",
+                      "transform": {
+                        "math": "(x+100)/40"
+                      }
+                    }
                   }
                 },
                 "description": "All mirrors.",
@@ -782,7 +794,7 @@
                 "children": {
                   "IsHeatingOn": {
                     "datatype": "boolean",
-                    "dbc": {
+                    "dbc2vss": {
                       "interval_ms": 1000,
                       "signal": "VCLEFT_mirrorHeatState",
                       "transform": {
@@ -803,7 +815,7 @@
                   },
                   "Pan": {
                     "datatype": "int8",
-                    "dbc": {
+                    "dbc2vss": {
                       "interval_ms": 100,
                       "signal": "VCRIGHT_mirrorTiltXPosition",
                       "transform": {
@@ -818,7 +830,7 @@
                   },
                   "Tilt": {
                     "datatype": "int8",
-                    "dbc": {
+                    "dbc2vss": {
                       "interval_ms": 100,
                       "signal": "VCRIGHT_mirrorTiltYPosition",
                       "transform": {
@@ -920,7 +932,7 @@
                   },
                   "IsOpen": {
                     "datatype": "boolean",
-                    "dbc": {
+                    "dbc2vss": {
                       "interval_ms": 1000,
                       "signal": "VCRIGHT_trunkLatchStatus",
                       "transform": {
@@ -953,7 +965,22 @@
                       }
                     },
                     "description": "Trunk open or closed. True = Open. False = Closed.",
-                    "type": "actuator"
+                    "type": "actuator",
+                    "vss2dbc": {
+                      "signal": "VCRIGHT_trunkLatchStatus",
+                      "transform": {
+                        "mapping": [
+                          {
+                            "from": true,
+                            "to": "LATCH_OPENED"
+                          },
+                          {
+                            "from": false,
+                            "to": "LATCH_CLOSED"
+                          }
+                        ]
+                      }
+                    }
                   }
                 },
                 "comment": "A trunk is a luggage compartment in a vehicle. Depending on vehicle, it can be either in the front or back of the vehicle. Some vehicles may have trunks both at the front and at the rear of the vehicle.",
@@ -978,7 +1005,7 @@
                     "children": {
                       "IsLevelLow": {
                         "datatype": "boolean",
-                        "dbc": {
+                        "dbc2vss": {
                           "interval_ms": 1000,
                           "signal": "VCFRONT_washerFluidLevel",
                           "transform": {
@@ -1314,7 +1341,7 @@
                       },
                       "IsOpen": {
                         "datatype": "boolean",
-                        "dbc": {
+                        "dbc2vss": {
                           "interval_ms": 500,
                           "signal": "VCLEFT_frontDoorState",
                           "transform": {
@@ -1496,7 +1523,7 @@
                       },
                       "IsOpen": {
                         "datatype": "boolean",
-                        "dbc": {
+                        "dbc2vss": {
                           "interval_ms": 500,
                           "signal": "VCLEFT_rearDoorState",
                           "transform": {
@@ -2904,7 +2931,7 @@
                       },
                       "IsBelted": {
                         "datatype": "boolean",
-                        "dbc": {
+                        "dbc2vss": {
                           "interval_ms": 1000,
                           "signal": "VCFRONT_driverBuckleStatus",
                           "transform": {
@@ -4979,7 +5006,7 @@
                               },
                               "IsFluidLevelLow": {
                                 "datatype": "boolean",
-                                "dbc": {
+                                "dbc2vss": {
                                   "interval_ms": 1000,
                                   "signal": "VCFRONT_brakeFluidLevel",
                                   "transform": {
@@ -5060,7 +5087,7 @@
                               },
                               "IsFluidLevelLow": {
                                 "datatype": "boolean",
-                                "dbc": {
+                                "dbc2vss": {
                                   "interval_ms": 1000,
                                   "signal": "VCFRONT_brakeFluidLevel",
                                   "transform": {
@@ -5216,7 +5243,7 @@
                               },
                               "IsFluidLevelLow": {
                                 "datatype": "boolean",
-                                "dbc": {
+                                "dbc2vss": {
                                   "interval_ms": 1000,
                                   "signal": "VCFRONT_brakeFluidLevel",
                                   "transform": {
@@ -5297,7 +5324,7 @@
                               },
                               "IsFluidLevelLow": {
                                 "datatype": "boolean",
-                                "dbc": {
+                                "dbc2vss": {
                                   "interval_ms": 1000,
                                   "signal": "VCFRONT_brakeFluidLevel",
                                   "transform": {
@@ -5435,7 +5462,7 @@
             "children": {
               "Angle": {
                 "datatype": "int16",
-                "dbc": {
+                "dbc2vss": {
                   "interval_ms": 100,
                   "signal": "SteeringAngle129",
                   "transform": {
@@ -5821,7 +5848,7 @@
           },
           "AmbientAirTemperature": {
             "datatype": "float",
-            "dbc": {
+            "dbc2vss": {
               "interval_ms": 1000,
               "signal": "VCFRONT_tempAmbientFiltered"
             },
@@ -5897,7 +5924,7 @@
           },
           "ControlModuleVoltage": {
             "datatype": "float",
-            "dbc": {
+            "dbc2vss": {
               "interval_ms": 1000,
               "signal": "PCS_dcdcLvBusVolt"
             },
@@ -5979,7 +6006,7 @@
           },
           "EngineLoad": {
             "datatype": "float",
-            "dbc": {
+            "dbc2vss": {
               "interval_ms": 100,
               "signal": "RearPower266",
               "transform": {
@@ -6672,7 +6699,7 @@
           },
           "Speed": {
             "datatype": "float",
-            "dbc": {
+            "dbc2vss": {
               "interval_ms": 100,
               "signal": "DI_uiSpeed"
             },
@@ -7072,17 +7099,20 @@
               },
               "Temperature": {
                 "datatype": "int16",
-                "dbc": {
+                "dbc2vss": {
                   "interval_ms": 1000,
                   "signal": "PTC_rightTempIGBT"
                 },
                 "description": "Motor temperature.",
                 "type": "sensor",
-                "unit": "celsius"
+                "unit": "celsius",
+                "vss2dbc": {
+                  "signal": "PTC_rightTempIGBT"
+                }
               },
               "Torque": {
                 "datatype": "int16",
-                "dbc": {
+                "dbc2vss": {
                   "interval_ms": 100,
                   "signal": "DIR_torqueActual"
                 },
@@ -7376,7 +7406,7 @@
                   },
                   "IsCharging": {
                     "datatype": "boolean",
-                    "dbc": {
+                    "dbc2vss": {
                       "interval_ms": 1000,
                       "signal": "CP_hvChargeStatus",
                       "transform": {
@@ -7707,7 +7737,7 @@
               },
               "CurrentGear": {
                 "datatype": "int8",
-                "dbc": {
+                "dbc2vss": {
                   "interval_ms": 100,
                   "signal": "DI_gear",
                   "transform": {
@@ -7791,7 +7821,7 @@
               },
               "IsParkLockEngaged": {
                 "datatype": "boolean",
-                "dbc": {
+                "dbc2vss": {
                   "interval_ms": 100,
                   "signal": "DI_gear",
                   "transform": {
@@ -7919,7 +7949,7 @@
       },
       "Speed": {
         "datatype": "float",
-        "dbc": {
+        "dbc2vss": {
           "interval_ms": 100,
           "signal": "DI_uiSpeed"
         },
@@ -7938,7 +7968,7 @@
         "children": {
           "IsConnected": {
             "datatype": "boolean",
-            "dbc": {
+            "dbc2vss": {
               "interval_ms": 3000,
               "signal": "VCLEFT_trailerDetected",
               "transform": {

--- a/dbc2val/test/test_example_mapping/test_example_mapping.py
+++ b/dbc2val/test/test_example_mapping/test_example_mapping.py
@@ -19,15 +19,18 @@
 ########################################################################
 
 from dbcfeederlib import dbc2vssmapper
+from dbcfeederlib import dbcparser
 import os
 
 # read config only once
-path = os.path.dirname(os.path.abspath(__file__)) + "/../../mapping/vss_4.0/vss_dbc.json"
-mapper: dbc2vssmapper.Mapper = dbc2vssmapper.Mapper(path)
+test_path = os.path.dirname(os.path.abspath(__file__))
+mapping_path = test_path + "/../../mapping/vss_4.0/vss_dbc.json"
+parser = dbcparser.DBCParser(test_path + "/../../Model3CAN.dbc")
+mapper: dbc2vssmapper.Mapper = dbc2vssmapper.Mapper(mapping_path, parser)
 
 
 def test_current_gear():
-    dbc_mapping = mapper["DI_gear"]
+    dbc_mapping = mapper.get_dbc2val_mappings("DI_gear")
     assert len(dbc_mapping) == 2
 
     # Do not make any assumption on which is which, we do not care
@@ -62,7 +65,7 @@ def test_current_gear():
 
 
 def test_parking_lock():
-    dbc_mapping = mapper["DI_gear"]
+    dbc_mapping = mapper.get_dbc2val_mappings("DI_gear")
     assert len(dbc_mapping) == 2
 
     # Do not make any assumption on which is which, we do not care
@@ -97,7 +100,7 @@ def test_parking_lock():
 
 
 def test_vehicle_speed():
-    dbc_mapping = mapper["DI_uiSpeed"]
+    dbc_mapping = mapper.get_dbc2val_mappings("DI_uiSpeed")
     assert len(dbc_mapping) == 2
 
     if dbc_mapping[0].vss_name == "Vehicle.Speed":
@@ -114,7 +117,7 @@ def test_vehicle_speed():
 
 
 def test_vehicle_obd_speed():
-    dbc_mapping = mapper["DI_uiSpeed"]
+    dbc_mapping = mapper.get_dbc2val_mappings("DI_uiSpeed")
     assert len(dbc_mapping) == 2
 
     if dbc_mapping[0].vss_name == "Vehicle.OBD.Speed":

--- a/dbc2val/test/test_mapping_error/test_mapping_error.py
+++ b/dbc2val/test/test_mapping_error/test_mapping_error.py
@@ -18,18 +18,21 @@
 # SPDX-License-Identifier: Apache-2.0
 ########################################################################
 
-
-
 from dbcfeederlib import dbc2vssmapper
+from dbcfeederlib import dbcparser
 import os
 import pytest
 import logging
 
 
 def test_unknown_transform(caplog, capsys):
-    path = os.path.dirname(os.path.abspath(__file__)) + "/test_unknown_transform.json"
+
+    test_path = os.path.dirname(os.path.abspath(__file__))
+    mapping_path = test_path + "/test_unknown_transform.json"
+    parser = dbcparser.DBCParser(test_path + "/../../Model3CAN.dbc")
+
     with pytest.raises(SystemExit) as excinfo:
-        mapper : dbc2vssmapper.Mapper = dbc2vssmapper.Mapper(path)
+        dbc2vssmapper.Mapper(mapping_path, parser)
     out, err = capsys.readouterr()
     assert excinfo.value.code == -1
     assert caplog.record_tuples == [("dbcfeederlib.dbc2vssmapper", logging.ERROR, "Unsupported transform for A.B")]


### PR DESCRIPTION
Current status:

Known/Intended limitations, not intended to be solved by this PR:

- val2dbc only supported for Databroker
- It is still called "dbc feeder". 

Tested:

- dbc2val mode
- val2dbc mode
- dbc2val+val2dbc mode
- val2dbc when Databroker requires authentication
- with KUKSA.val server (we shall test that you get an error for val2dbc and no regressions for dbc2val)
- Running dbc2val as docker container