### PR TITLE
Bugfix Mapper not iterable

### DIFF
--- a/dbc2val/dbcfeederlib/dbc2vssmapper.py
+++ b/dbc2val/dbcfeederlib/dbc2vssmapper.py
@@ -434,3 +434,9 @@ class Mapper:
             if can_mapping.last_dbc_value is not None:
                 res[can_mapping.dbc_name] = can_mapping.last_dbc_value
         return res
+
+    def __contains__(self, key):
+        return key in self.dbc2val_mapping.keys()
+
+    def __getitem__(self, item):
+        return self.dbc2val_mapping[item]


### PR DESCRIPTION
j1939reader is using the Mapper as a Iterable, but the functions were missing:

The fix makes the Mapper iterable, same change as in `vss2ddsmapper.py` (see <https://github.com/eclipse/kuksa.val.feeders/blob/main/dds2val/ddsproviderlib/vss2ddsmapper.py#L117>)

```
2023-06-30 06:36:56,452 WARNING dbcfeederlib.j1939reader: Error decoding message [PGN: CCVS]
Traceback (most recent call last):
  File "/workspaces/leda-example-applications-fork/canbus-j1939/kuksa.val.feeders/dbc2val/dbcfeederlib/j1939reader.py", line 76, in on_message
    if k in self.mapper:
TypeError: argument of type 'Mapper' is not iterable
```
