### PR TITLE
Fix kuksa-client dependencies

### DIFF
--- a/csv_provider/Dockerfile
+++ b/csv_provider/Dockerfile
@@ -29,7 +29,7 @@ RUN python3 -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
 RUN /opt/venv/bin/python3 -m pip install --upgrade pip \
-    && pip3 install --no-cache-dir -r requirements.txt
+    && pip3 install --no-cache-dir --pre -r requirements.txt
 
 
 RUN pip3 install wheel scons && pip3 install pyinstaller

--- a/csv_provider/requirements.txt
+++ b/csv_provider/requirements.txt
@@ -1,1 +1,2 @@
-kuksa-client>0.3
+# If pre-releases (e.g. X.YaN) are specified you must use --pre when installing
+kuksa-client >= 0.4a4

--- a/dbc2val/requirements.in
+++ b/dbc2val/requirements.in
@@ -14,6 +14,9 @@
 #
 # pip-compile requirements.in
 #
+# If you depend on pre-releases (of e.g. kuksa-client) use
+#
+# pip-compile --pre requirements.in
 
 python-can ~= 4.1
 pyserial ~= 3.5
@@ -21,7 +24,6 @@ cantools ~= 38.0
 pyyaml ~= 6.0
 can-j1939 ~= 2.0
 py_expression_eval ~= 0.3
-# Larger than 0.3, includes pre-released if pip installed with --pre
-kuksa-client > 0.3
+kuksa-client >= 0.4a4
 types-PyYAML ~= 6.0
 types-protobuf ~= 4.21

--- a/dbc2val/requirements.txt
+++ b/dbc2val/requirements.txt
@@ -34,7 +34,7 @@ iniconfig==2.0.0
     # via pytest
 jsonpath-ng==1.5.3
     # via kuksa-client
-kuksa-client==0.4.0a3
+kuksa-client==0.4.0a4
     # via -r requirements.in
 msgpack==1.0.5
     # via python-can

--- a/dds2val/requirements/requirements-test.txt
+++ b/dds2val/requirements/requirements-test.txt
@@ -1,6 +1,7 @@
+# If pre-releases (e.g. X.YaN) are specified you must use --pre when installing
 pytest
 pytest-html
 pytest-cov
 pytest-asyncio
 py
-kuksa-client > 0.3
+kuksa-client >= 0.4a4

--- a/dds2val/requirements/requirements.txt
+++ b/dds2val/requirements/requirements.txt
@@ -1,6 +1,7 @@
+# If pre-releases (e.g. X.YaN) are specified you must use --pre when installing
 # feeder
 cyclonedds
-kuksa-client > 0.3
+kuksa-client >= 0.4a4
 # mapper
 pyyaml
 py-expression-eval

--- a/gps2val/requirements.txt
+++ b/gps2val/requirements.txt
@@ -1,2 +1,3 @@
-kuksa-client > 0.3
+# If pre-releases (e.g. X.YaN) are specified you must use --pre when installing
+kuksa-client >= 0.4a4
 gpsdclient


### PR DESCRIPTION
It seems we use cache when calling pypi, but we want a fresh build