### PR TITLE
Support loading CAN message definition files of arbitrary types

### DIFF
--- a/dbc2val/Readme.md
+++ b/dbc2val/Readme.md
@@ -238,7 +238,7 @@ A smaller excerpt from the above sample, with fewer signals.
 | Command Line Argument | Environment Variable            | Config File Property    | Default Value                    | Description         |
 |:----------------------|:--------------------------------|:------------------------|:---------------------------------|---------------------|
 | *--config*            | -                               | -                       | *See below*                      | Configuration file  |
-| *--dbcfile*           | *DBC_FILE*                      | *[can].dbc*             |                                  | DBC file(s) used for parsing CAN traffic. You may specify multiple file names separated by comma|
+| *--dbcfile*           | *DBC_FILE*                      | *[can].dbc*             |                                  | DBC file(s) used for parsing CAN traffic. You may specify multiple file names separated by comma. Supports parsing of [arbitrary DB file types](https://github.com/cantools/cantools#about). |
 | *--dumpfile*          | *CANDUMP_FILE*                  | *[can].candumpfile*     |                                  | Replay recorded CAN traffic from dumpfile |
 | *--canport*           | *CAN_PORT*                      | *[can].port*            |                                  | Read from this CAN interface |
 | *--use-j1939*         | *USE_J1939*                     | *[can].j1939*           | `False`                          | Use J1939 when decoding CAN frames. Setting the environment variable to any value is equivalent to activating the switch on the command line. |

--- a/dbc2val/dbcfeederlib/dbcparser.py
+++ b/dbc2val/dbcfeederlib/dbcparser.py
@@ -21,7 +21,7 @@
 import logging
 import sys
 from typing import Set, Optional, Dict, cast
-import cantools
+import cantools.database
 
 log = logging.getLogger(__name__)
 
@@ -34,7 +34,7 @@ class DBCParser:
         for name in dbcfile.split(","):
             filename = name.strip()
             if filename in found_names:
-                log.warn("The DBC file {} has already been read, ignoring it!".format(filename))
+                log.warning("The DBC file {} has already been read, ignoring it!".format(filename))
                 continue
             found_names.add(filename)
             if first:
@@ -49,7 +49,10 @@ class DBCParser:
                     sys.exit(-1)
             else:
                 log.info("Adding definitions from {}".format(filename))
-                self.db.add_dbc_file(filename)
+                # determine DB file format by means of filename suffix
+                tmp_database: cantools.db.Database = cantools.database.load_file(filename, strict=use_strict_parsing)
+                # "normalize" definitions to DBC format, before adding them
+                self.db.add_dbc_string(tmp_database.as_dbc_string())
 
         # Init some dictionaries to speed up search
         self.signal_to_canid: Dict[str, Optional[int]] = {}

--- a/dbc2val/test/test_dbc/test1_1.kcd
+++ b/dbc2val/test/test_dbc/test1_1.kcd
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<NetworkDefinition xmlns="http://kayak.2codeornot2code.org/1.0">
+    <Document name="test1_1.kcd" date="Wed Jul 05 15:13:39 CEST 2023"></Document>
+    <Bus name="Private">
+        <Message id="0x16" name="ID016DI_bmsRequest" length="1">
+            <Signal name="DI_bmsOpenContactorsRequest" offset="4">
+                <Value/>
+            </Signal>
+            <Signal length="4" name="DI_bmsRequestInterfaceVersion" offset="0">
+                <Value max="15.0"/>
+            </Signal>
+        </Message>
+    </Bus>
+</NetworkDefinition>

--- a/dbc2val/test/test_dbc/test1_2.kcd
+++ b/dbc2val/test/test_dbc/test1_2.kcd
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<NetworkDefinition xmlns="http://kayak.2codeornot2code.org/1.0">
+    <Document name="test1_2.kcd" date="Wed Jul 05 15:13:39 CEST 2023"></Document>
+    <Bus name="Private">
+        <Message id="0x129" name="ID129SteeringAngle" length="8" interval="10">
+            <Signal length="8" name="SteeringSensorC129" offset="56">
+                <Value max="255.0"/>
+            </Signal>
+            <Signal length="8" name="SteeringSensorB129" offset="48">
+                <Value max="255.0"/>
+            </Signal>
+            <Signal length="2" name="SteeringSensorA129" offset="46">
+                <Value max="3.0"/>
+            </Signal>
+            <Signal length="14" name="SteeringSpeed129" offset="32">
+                <Notes>Steering Speed</Notes>
+                <Value slope="0.5" intercept="-4096.0" unit="D/S" min="-4096.0" max="4095.5"/>
+            </Signal>
+            <Signal length="14" name="SteeringAngle129" offset="16">
+                <Notes>Steering Angle</Notes>
+                <Value slope="0.1" intercept="-819.2" unit="Deg" min="-819.2" max="819.1"/>
+            </Signal>
+        </Message>
+    </Bus>
+</NetworkDefinition>

--- a/dbc2val/test/test_dbc/test_kcd.py
+++ b/dbc2val/test/test_dbc/test_kcd.py
@@ -1,0 +1,57 @@
+#!/usr/bin/python3
+
+########################################################################
+# Copyright (c) 2023 Robert Bosch GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+########################################################################
+
+from dbcfeederlib import dbcparser
+import os
+
+# read config only once
+test_path = os.path.dirname(os.path.abspath(__file__))
+
+
+def test_single_kcd():
+
+    parser = dbcparser.DBCParser(test_path + "/test1_1.kcd")
+    assert parser.get_canid_for_signal('DI_bmsRequestInterfaceVersion') == 0x16
+
+
+def test_split_kcd():
+    """
+    This verifies that we can read multiple KCD files.
+    """
+    parser = dbcparser.DBCParser(test_path + "/test1_1.kcd," + test_path + "/test1_2.kcd")
+    assert parser.get_canid_for_signal('DI_bmsRequestInterfaceVersion') == 0x16
+    assert parser.get_canid_for_signal('SteeringAngle129') == 0x129
+
+
+def test_mixed_file_types():
+    """
+    This verifies that we can read files of different type.
+    """
+    parser = dbcparser.DBCParser(test_path + "/test1_1.kcd," + test_path + "/test1_2.dbc")
+    assert parser.get_canid_for_signal('DI_bmsRequestInterfaceVersion') == 0x16
+    assert parser.get_canid_for_signal('SteeringAngle129') == 0x129
+
+
+def test_duplicated_dbc():
+    """
+    Load original KCD multiple times
+    """
+    parser = dbcparser.DBCParser(test_path + "/test1_1.kcd," + test_path + "/test1_1.kcd")
+    assert parser.get_canid_for_signal('DI_bmsRequestInterfaceVersion') == 0x16


### PR DESCRIPTION
Changed mechanism for adding message definitions from additional files to support arbitrary file formats.