### PR TITLE
Use default (24 hours) lifetime for ttl.sh images

### DIFF
--- a/.github/workflows/kuksa_gps_feeder.yml
+++ b/.github/workflows/kuksa_gps_feeder.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 env:
-  EPHEMERAL_IMAGE: "ttl.sh/kuksa.val.feeders/gps-${{ github.sha }}:1h"
+  EPHEMERAL_IMAGE: "ttl.sh/kuksa.val.feeders/gps-${{ github.sha }}"
 
 jobs:
 

--- a/.github/workflows/someip2val_build.yml
+++ b/.github/workflows/someip2val_build.yml
@@ -134,7 +134,7 @@ jobs:
           platforms: linux/amd64, linux/arm64
           tags: |
             ${{ steps.meta.outputs.tags }}
-            ttl.sh/kuksa.val.feeders/someip-feeder-${{github.sha}}:8h
+            ttl.sh/kuksa.val.feeders/someip-feeder-${{github.sha}}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: "Build someip2val container and push to ttl.sh"
@@ -148,5 +148,5 @@ jobs:
           context: "./someip2val"
           platforms: linux/amd64, linux/arm64
           tags: |
-            ttl.sh/kuksa.val.feeders/someip-feeder-${{github.sha}}:8h
+            ttl.sh/kuksa.val.feeders/someip-feeder-${{github.sha}}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Related to https://github.com/eclipse/kuksa.val/issues/598