### PR TITLE
Improve printout for regsitered signal when using KUKSA.val Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Name | Description
 [SOME/IP feeder](./someip2val) | SOME/IP feeder for KUKSA.val Databroker
 [DDS Provider](./dds2val)      | DDS provider for KUKSA.val Databroker
 [Replay](./replay)             | KUKSA.val Server replay script for previously recorded files, created by providing KUKSA.val Server with `--record` argument
-[CSV provider](./csv_provider) | Script to replay VSS signals to `kuksa.val` databroker as defined in a CSV-file
+[CSV provider](./csv_provider) | Script to replay VSS signals to KUKSA.val Databroker as defined in a CSV-file
 
 ## Pre-commit set up
 This repository is set up to use [pre-commit](https://pre-commit.com/) hooks.

--- a/csv_provider/README.md
+++ b/csv_provider/README.md
@@ -58,3 +58,7 @@ so one of those names needs to be specified if connecting to `127.0.0.1`. An exa
 ```
 python provider.py --cacertificate /home/user/kuksa.val/kuksa_certificates/CA.pem --tls-server-name Server
 ```
+
+## Limitations
+
+* CSV Provider does not support authentication, i.e. it is impossible to communicate with a Databroker that require authentication!

--- a/dbc2val/dbcfeederlib/databrokerclientwrapper.py
+++ b/dbc2val/dbcfeederlib/databrokerclientwrapper.py
@@ -19,9 +19,9 @@ from typing import Dict, List
 
 import os
 import contextlib
+from pathlib import Path
 
 import grpc.aio
-from pathlib import Path
 
 import kuksa_client.grpc  # type: ignore[import]
 from kuksa_client.grpc import Datapoint

--- a/dbc2val/dbcfeederlib/serverclientwrapper.py
+++ b/dbc2val/dbcfeederlib/serverclientwrapper.py
@@ -84,9 +84,10 @@ class ServerClientWrapper(clientwrapper.ClientWrapper):
         # Check if signal is defined in server
         resp = json.loads(self._kuksa.getMetaData(vss_name))
         if "error" in resp:
-            log.error(f"Signal {vss_name} appears not to be registered: {resp['error']}")
+            log.error("Signal %s appears not to be registered: %s", vss_name, resp['error'])
             return False
-        log.info(f"Signal {vss_name} is registered: {resp}")
+        log.info("Signal %s is registered", vss_name)
+        log.debug("Signal %s registration information: %s", vss_name, resp)
         return True
 
     def update_datapoint(self, name: str, value: Any) -> bool:

--- a/dds2val/README.md
+++ b/dds2val/README.md
@@ -1,6 +1,6 @@
 # DDS Provider
 
-The DDS provider provides data from an DDS middleware/API. For further understanding of the DDS middleware/API see [this](https://www.dds-foundation.org/what-is-dds-3/). The DDS provider only works with the KUKSA databroker. The KUKSA C++ server is not supported.
+The DDS provider provides data from an DDS middleware/API. For further understanding of the DDS middleware/API see [this](https://www.dds-foundation.org/what-is-dds-3/). The DDS provider only works with the KUKSA Databroker. The KUKSA C++ Server is not supported.
 
 ## How to build
 


### PR DESCRIPTION
No reason to give verbose information in INFO mode 
Replacing f-strings with other construct
(reason: https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/logging-fstring-interpolation.html)