### PR TITLE
Change dbc2val TLS default to True

### DIFF
--- a/dbc2val/README.md
+++ b/dbc2val/README.md
@@ -248,7 +248,7 @@ A smaller excerpt from the above sample, with fewer signals.
 | *--server-type*       | *SERVER_TYPE*                   | *[general].server_type* | `kuksa_databroker`               | Which type of server the feeder should connect to (`kuksa_val_server` or `kuksa_databroker`) |
 | -                     | *KUKSA_ADDRESS*                 | *[general].ip*          | `127.0.0.1`                      | IP address for Server/Databroker |
 | -                     | *KUKSA_PORT*                    | *[general].port*        | `55555`                          | Port for Server/Databroker |
-| -                     | -                               | *[general].tls*         | `False`                          | Shall tls be used for Server/Databroker connection? |
+| -                     | -                               | *[general].tls*         | `True`                          | Shall tls be used for Server/Databroker connection? |
 | -                     | -                               | *[general].root_ca_path* | *Undefined*                      | Path to root CA: Only needed if using TLS |
 | -                     | -                               | *[general].tls_server_name* | *Undefined*                   | TLS server name, may be needed if addressing a server by IP-name |
 | -                     | -                               | *[general].token*       | *Undefined*                      | Token path. Only needed if Databroker/Server requires authentication |
@@ -303,10 +303,11 @@ must be set. The default config file include (commented) values to use if using 
 
 ### Using kuksa-client with a server requiring TLS
 
-The [default configuration file](config/dbc_feeder.ini) does not specify that TLS shall be used.
-If the KUKSA.val Databroker or KUKSA.val Server requires authentication the `tls` attribute in the config file
-must be set to `True` and `root_ca_path` must be set.
-The default config file include (commented) values to use if using KUKSA.val example certificates.
+The [default configuration file](config/dbc_feeder.ini) specifies that TLS shall be used.
+If the KUKSA.val Databroker or KUKSA.val Server explicitly or implicitly has been configured not to use TLS,
+then the `tls` attribute in the config file must be set to `False`.
+If the KUKSA.val Databroker or KUKSA.val Server requires authentication the `root_ca_path` must be set.
+The default config file include values to use if using KUKSA.val example certificates.
 
 The feeder verifies that the Databroker/Server presents a certificate with a name matching the server.
 The KUKSA.val default server certificate include `Server`, `localhost` and `127.0.0.1` as names, but due to a limitation

--- a/dbc2val/config/dbc_feeder.ini
+++ b/dbc2val/config/dbc_feeder.ini
@@ -29,9 +29,10 @@ ip = 127.0.0.1
 port = 55555
 # port = 8090
 
-# Shall TLS be used (default False for Databroker, True for KUKSA.val Server)
-tls = False
-# tls = True
+# Shall TLS be used
+# Currently KUKSA Server use TLS by default, but KUKSA Databroker does not require TLS by default
+tls = True
+# tls = False
 
 # TLS-related settings
 # Path to root CA, needed if using TLS

--- a/dbc2val/dbcfeeder.py
+++ b/dbc2val/dbcfeeder.py
@@ -436,7 +436,7 @@ def _get_kuksa_val_client(command_line_parser: argparse.Namespace,
         client.set_port(config.getint(CONFIG_SECTION_GENERAL, CONFIG_OPTION_PORT))
 
     if config.has_option(CONFIG_SECTION_GENERAL, CONFIG_OPTION_TLS_ENABLED):
-        client.set_tls(config.getboolean(CONFIG_SECTION_GENERAL, CONFIG_OPTION_TLS_ENABLED, fallback=False))
+        client.set_tls(config.getboolean(CONFIG_SECTION_GENERAL, CONFIG_OPTION_TLS_ENABLED, fallback=True))
 
     if config.has_option(CONFIG_SECTION_GENERAL, CONFIG_OPTION_ROOT_CA_PATH):
         path = config.get(CONFIG_SECTION_GENERAL, CONFIG_OPTION_ROOT_CA_PATH)

--- a/dbc2val/dbcfeederlib/databrokerclientwrapper.py
+++ b/dbc2val/dbcfeederlib/databrokerclientwrapper.py
@@ -44,9 +44,11 @@ class DatabrokerClientWrapper(clientwrapper.ClientWrapper):
     https://github.com/eclipse/kuksa.val/blob/master/kuksa-client/kuksa_client/grpc/__init__.py
     """
     # No default token path given as no default token included in packages/containers
+    # Note that Databroker by default does not requie TLS; so if using Databroker with default setup
+    # then you must explicitly set tls to False
     def __init__(self, ip: str = "127.0.0.1", port: int = 55555,
                  token_path: str = "",
-                 tls: bool = False):
+                 tls: bool = True):
         """
         Init Databroker client wrapper, by default with TLS
         """

--- a/dds2val/ddsprovider.py
+++ b/dds2val/ddsprovider.py
@@ -58,8 +58,6 @@ async def main():
         "MAPPING_FILE", str(Path(__file__).parent / "mapping/latest/mapping.yml")
     )
 
-    # Collect data for TLS connection, for now default is no TLS
-    # To keep backward compatibility not using TLS is default
     if os.environ.get("VDB_ROOT_CA_PATH"):
         root_ca_path = os.environ.get("VDB_ROOT_CA_PATH")
     else:


### PR DESCRIPTION
Practical differences:

- If use default config for your Databroker instance (no TLS) then you cannot use dbcfeeder defult config (TLS), i.e. just must either change databroker config to use TLS or change dbcfeeder config to not use TLS

Fixes #133 

Note: No other changes to support for example TLS as command line parameter, there we need a general discussion first