### PR TITLE
Introduce CAN reader hierarchy

### DIFF
--- a/dbc2val/dbcfeederlib/canclient.py
+++ b/dbc2val/dbcfeederlib/canclient.py
@@ -23,24 +23,24 @@ class CANClient:
     """
     Wrapper class to hide dependency to CAN package.
     Reason is to make it simple to replace the CAN package dependency with something else if your KUKSA.val
-    integration cannot interact directly with CAN, but rather interacts with some custom CAN solution/middleware
+    integration cannot interact directly with CAN, but rather interacts with some custom CAN solution/middleware.
     """
 
     def __init__(self, *args, **kwargs):
-        self.bus = can.interface.Bus(*args, **kwargs)  # pylint: disable=abstract-class-instantiated
+        # pylint: disable=abstract-class-instantiated
+        self._bus = can.interface.Bus(*args, **kwargs)
 
     def stop(self):
-        if self.bus:
-            self.bus.shutdown()
-            self.bus = None
+        """Shut down CAN bus."""
+        self._bus.shutdown()
 
     def recv(self, timeout: int = 1) -> Optional[canmessage.CANMessage]:
-        """Wait for message from CAN"""
+        """Receive message from CAN bus."""
         try:
-            msg = self.bus.recv(timeout)
+            msg = self._bus.recv(timeout)
         except can.CanError:
             msg = None
-            if self.bus:
+            if self._bus:
                 log.error("Error while waiting for recv from CAN", exc_info=True)
             else:
                 # This is expected if we are shutting down
@@ -52,11 +52,11 @@ class CANClient:
         return None
 
     def send(self, arbitration_id, data):
-        """Send message to CAN"""
+        """Write message to CAN bus."""
         msg = can.Message(arbitration_id=arbitration_id, data=data)
         try:
-            self.bus.send(msg)
-            log.debug(f"Message sent on {self.bus.channel_info}")
-            log.debug(f"Message: {msg}")
+            self._bus.send(msg)
+            if log.isEnabledFor(logging.DEBUG):
+                log.debug("Sent message [channel: %s]: %s", self._bus.channel_info, msg)
         except can.CanError:
             log.error("Failed to send message via CAN bus")

--- a/dbc2val/dbcfeederlib/canreader.py
+++ b/dbc2val/dbcfeederlib/canreader.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+
+#################################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License 2.0 which is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+import logging
+import time
+
+from abc import ABC, abstractmethod
+
+from dbcfeederlib.canplayer import CANplayer
+from dbcfeederlib.dbc2vssmapper import Mapper, VSSObservation
+from typing import Any, Dict, Optional
+from queue import Queue
+
+log = logging.getLogger(__name__)
+
+
+class CanReader(ABC):
+    """
+    Provides means to read messages from a CAN bus.
+    """
+    def __init__(self, rxqueue: Queue, mapper: Mapper, can_port: str, dump_file: Optional[str] = None):
+        """
+        This init method is only supposed to be called by subclass' __init__ functions.
+        """
+        self._running = False
+        self._queue = rxqueue
+        self._mapper = mapper
+        self._running = False
+        self._can_player: Optional[CANplayer] = None
+
+        can_filters = mapper.can_frame_id_whitelist()
+        log.info("Using CAN frame ID whitelist=%s", can_filters)
+        self._can_kwargs: Dict[str, Any] = {"interface": "socketcan", "channel": can_port, "can_filters": can_filters}
+        if dump_file is not None:
+            self._can_kwargs["interface"] = "virtual"
+            self._can_kwargs["bitrate"] = 500000
+            self._can_player = CANplayer(dump_file, can_port)
+
+    def is_running(self) -> bool:
+        return self._running
+
+    @abstractmethod
+    def _start_can_bus_listener(self):
+        """
+        Start listening to CAN bus.
+        """
+        pass
+
+    def start(self):
+        """
+        Start processing of messages.
+        """
+        self._running = True
+        self._start_can_bus_listener()
+        if self._can_player is not None:
+            self._can_player.start()
+
+    @abstractmethod
+    def _stop_can_bus_listener(self):
+        """
+        Stop listening to CAN bus.
+        """
+        pass
+
+    def stop(self):
+        if self._can_player is not None:
+            self._can_player.stop()
+        self._running = False
+        self._stop_can_bus_listener()
+
+    def _process_can_message(self, frame_id: int, data: Any):
+        try:
+            message_def = self._mapper.get_message_for_canid(frame_id)
+            if message_def is not None:
+                decode = message_def.decode(bytes(data), allow_truncated=True)
+                if log.isEnabledFor(logging.DEBUG):
+                    log.debug("Decoded message: %s", str(decode))
+                rx_time = time.time()
+                for signal_name, raw_value in decode.items():  # type: ignore
+                    for signal_mapping in self._mapper.get_dbc2vss_mappings(signal_name):
+                        if signal_mapping.time_condition_fulfilled(rx_time):
+                            log.debug(
+                                "Queueing %s, triggered by %s, raw value %s",
+                                signal_mapping.vss_name, signal_name, raw_value
+                            )
+                            self._queue.put(VSSObservation(
+                                signal_name, signal_mapping.vss_name, raw_value, rx_time))
+                        else:
+                            log.debug(
+                                "Ignoring %s, triggered by %s, raw value %s",
+                                signal_mapping.vss_name, signal_name, raw_value
+                            )
+        except Exception:
+            log.warning("Error processing CAN message with frame ID: %#x", frame_id, exc_info=True)

--- a/dbc2val/dbcfeederlib/databrokerclientwrapper.py
+++ b/dbc2val/dbcfeederlib/databrokerclientwrapper.py
@@ -200,7 +200,7 @@ class DatabrokerClientWrapper(clientwrapper.ClientWrapper):
         return True
 
     async def subscribe(self, vss_names: List[str], callback):
-        """Creates a subscription and calls the callback when data received"""
+        """Create a subscription and invoke the callback when data received."""
         entries = []
         for name in vss_names:
             # Always subscribe to target

--- a/dbc2val/dbcfeederlib/dbcreader.py
+++ b/dbc2val/dbcfeederlib/dbcreader.py
@@ -19,92 +19,36 @@
 ########################################################################
 
 import threading
-import time
 import logging
 
 from queue import Queue
+from typing import Optional
 
+from dbcfeederlib.canclient import CANClient
+from dbcfeederlib import canreader
 from dbcfeederlib import dbc2vssmapper
-from dbcfeederlib import canclient
 
 log = logging.getLogger(__name__)
 
 
-class DBCReader:
-    def __init__(self, rxqueue: Queue, mapper: dbc2vssmapper.Mapper):
-        self._queue = rxqueue
-        self._mapper = mapper
-        self._canidwl = self.get_whitelist()
-        log.info("CAN ID whitelist=%s", self._canidwl)
-        self._running = False
-        self._canclient = None
+class DBCReader(canreader.CanReader):
+    def __init__(self, rxqueue: Queue, mapper: dbc2vssmapper.Mapper, can_port: str, dump_file: Optional[str] = None):
+        super().__init__(rxqueue, mapper, can_port, dump_file)
 
-    def start_listening(self, *args, **kwargs):
-        """Start listening to CAN bus
+    def _rx_worker(self):
 
-        Arguments are passed directly to :class:`can.BusABC`. Typically these
-        may include:
+        log.info("Starting to receive CAN messages fom bus")
+        while self.is_running():
+            msg = self._canclient.recv(timeout=1)
+            if msg is not None:
+                log.debug("Processing CAN message with frame ID %#x", msg.get_arbitration_id)
+                self._process_can_message(msg.get_arbitration_id(), msg.get_data())
+        log.info("Stopped receiving CAN messages from bus")
 
-        :param channel:
-            Backend specific channel for the CAN interface.
-        :param str bustype:
-            Name of the interface. See
-            `python-can manual <https://python-can.readthedocs.io/en/latest/configuration.html#interface-names>`__
-            for full list of supported interfaces.
-        :param int bitrate:
-            Bitrate in bit/s.
-        """
-        self._running = True
-        self._canclient = canclient.CANClient(*args, **kwargs)
+    def _start_can_bus_listener(self):
+        self._canclient = CANClient(**self._can_kwargs)
         rx_thread = threading.Thread(target=self._rx_worker)
         rx_thread.start()
 
-    def get_whitelist(self):
-        log.debug("Generating CAN ID whitelist")
-        white_list = []
-        for signal_name in self._mapper.get_dbc2vss_entries():
-            canid = self._mapper.get_canid_for_signal(signal_name)
-            if canid is not None and canid not in white_list:
-                log.debug("Adding CAN frame id %d of message containing signal %s to white list", canid, signal_name)
-                white_list.append(canid)
-        return white_list
-
-    def _process_message(self, frame_id: int, data: bytearray):
-
-        log.debug("processing message with frame ID %#x from CAN bus", frame_id)
-        try:
-            message_def = self._mapper.get_message_for_canid(frame_id)
-            if message_def is not None:
-                decode = message_def.decode(bytes(data), allow_truncated=True)
-                if log.isEnabledFor(logging.DEBUG):
-                    log.debug("Decoded message: %s", str(decode))
-
-                rx_time = time.time()
-                for k, v in decode.items():  # type: ignore
-                    vss_mappings = self._mapper.get_dbc2vss_mappings(k)
-                    for signal in vss_mappings:
-                        if signal.time_condition_fulfilled(rx_time):
-                            log.debug("Queueing %s, triggered by %s, raw value %s", signal.vss_name, k, v)
-                            self._queue.put(dbc2vssmapper.VSSObservation(k, signal.vss_name, v, rx_time))
-                        else:
-                            log.debug("Ignoring %s, triggered by %s, raw value %s", signal.vss_name, k, v)
-        except Exception:
-            log.warning("Error decoding message with frame ID: %#x", frame_id, exc_info=True)
-
-    def _rx_worker(self):
-        log.info("Starting Rx thread")
-        while self._running:
-            can_message = self._canclient.recv(timeout=1)
-            if can_message is not None:
-                frame_id = can_message.get_arbitration_id()
-                if frame_id in self._canidwl:
-                    self._process_message(frame_id, can_message.get_data())
-                else:
-                    log.debug("ignoring CAN message with frame ID %s not on whitelist", frame_id)
-        log.info("Stopped Rx thread")
-
-    def stop(self):
-        self._running = False
-        if self._canclient:
-            self._canclient.stop()
-            self._canclient = None
+    def _stop_can_bus_listener(self):
+        self._canclient.stop()

--- a/dbc2val/test/test_mapping_error/test_mapping_error.py
+++ b/dbc2val/test/test_mapping_error/test_mapping_error.py
@@ -18,10 +18,12 @@
 # SPDX-License-Identifier: Apache-2.0
 ########################################################################
 
-from dbcfeederlib import dbc2vssmapper
 import os
-import pytest  # type: ignore
 import logging
+
+import pytest  # type: ignore
+
+from dbcfeederlib import dbc2vssmapper
 
 
 def test_unknown_transform(caplog, capsys):
@@ -34,4 +36,6 @@ def test_unknown_transform(caplog, capsys):
         dbc2vssmapper.Mapper(mapping_path, dbc_file_names)
     out, err = capsys.readouterr()
     assert excinfo.value.code == -1
-    assert caplog.record_tuples == [("dbcfeederlib.dbc2vssmapper", logging.ERROR, "Unsupported transform for A.B")]
+    assert caplog.record_tuples == [
+        ("dbcfeederlib.dbc2vssmapper", logging.ERROR, "Unsupported transformation definition for A.B")
+    ]


### PR DESCRIPTION
Increase cohesion and reduce coupling between components by introducing
an abstract CANReader class which defines the responsibilities and
behavior of the DBCReader and J1939Reader.

Modified readers to consistently use HW based CAN frame filtering based
on DBC message and DBC<->VSS mapping definitions.

Also added typing information to functions and member variables to
improve readability and maintainability.