### PR TITLE
Fix server_type handling

### DIFF
--- a/dbc2val/dbcfeeder.py
+++ b/dbc2val/dbcfeeder.py
@@ -480,7 +480,7 @@ def _get_command_line_args_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--server-type",
         help="The type of KUKSA.val server to write/read VSS signal to/from",
-        choices=[server_type.name for server_type in ServerType]
+        choices=[server_type.value for server_type in ServerType]
     )
     parser.add_argument(
         "--lax-dbc-parsing",

--- a/dbc2val/test/test_arguments/__init__.py
+++ b/dbc2val/test/test_arguments/__init__.py
@@ -1,0 +1,12 @@
+########################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License 2.0 which is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+########################################################################

--- a/dbc2val/test/test_arguments/test_arguments.py
+++ b/dbc2val/test/test_arguments/test_arguments.py
@@ -1,0 +1,46 @@
+########################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License 2.0 which is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+########################################################################
+
+import pytest
+import os
+
+
+@pytest.fixture
+def change_test_dir(request, monkeypatch):
+    # To make sure we run from test directory
+    monkeypatch.chdir(request.fspath.dirname)
+
+
+@pytest.mark.parametrize("requested_server, ok_expected", [
+    ('kuksa_databroker', True),
+    ('kuksa_val_server', True),
+    ('KUKSA_DATABROKER', False),
+    ('KUKSA_VAL_SERVER', False)])
+def test_server_type(requested_server, ok_expected, change_test_dir):
+    test_str = "../../dbcfeeder.py --server-type " + requested_server + "  --help > out.txt 2>&1"
+    result = os.system(test_str)
+    assert os.WIFEXITED(result)
+    if ok_expected:
+        assert os.WEXITSTATUS(result) == 0
+        # Check that we get normal help
+        test_str = r'grep "\-\-server-type {kuksa_val_server,kuksa_databroker}" out.txt > /dev/null'
+    else:
+        assert os.WEXITSTATUS(result) != 0
+        # Check that we get error
+        test_str = r'grep "(choose from ' + r"'kuksa_val_server', 'kuksa_databroker')" + r'" out.txt > /dev/null'
+
+    result = os.system(test_str)
+    os.system("cat out.txt")
+    os.system("rm -f out.json out.txt")
+    assert os.WIFEXITED(result)
+    assert os.WEXITSTATUS(result) == 0


### PR DESCRIPTION
Previously you would get an error whatever you specified. This change behavior to expect lower case name:

I.e. you should call:

```
erik@debian3:~/kuksa.val.feeders/dbc2val$ ./dbcfeeder.py --server-type kuksa_databroker
2023-09-19 12:58:13,256 INFO dbcfeeder: Reading configuration from file: config/dbc_feeder.ini
2023-09-19 12:58:13,257 INFO dbcfeeder: DBC2VAL mode is: True
2023-09-19 12:58:13,257 INFO dbcfeeder: VAL2DBC mode is: False
...
```
If you try uppercase you get an error:

```
erik@debian3:~/kuksa.val.feeders/dbc2val$ ./dbcfeeder.py --server-type KUKSA_DATABROKER
usage: dbcfeeder.py [-h] [--config FILE] [--dbcfile FILE] [--dumpfile FILE] [--canport DEVICE] [--use-j1939] [--use-socketcan] [--mapping FILE] [--dbc-default FILE] [--server-type {kuksa_val_server,kuksa_databroker}] [--lax-dbc-parsing]
                    [--dbc2val] [--no-dbc2val] [--val2dbc] [--no-val2dbc]
dbcfeeder.py: error: argument --server-type: invalid choice: 'KUKSA_DATABROKER' (choose from 'kuksa_val_server', 'kuksa_databroker')

```

**How it worked before this PR**

You were doomed if you used `kuksa_databroker`

```
erik@debian3:~/kuksa.val.feeders/dbc2val$ ./dbcfeeder.py --server-type kuksa_databroker
usage: dbcfeeder.py [-h] [--config FILE] [--dbcfile FILE] [--dumpfile FILE] [--canport DEVICE] [--use-j1939] [--use-socketcan] [--mapping FILE] [--dbc-default FILE] [--server-type {KUKSA_VAL_SERVER,KUKSA_DATABROKER}] [--lax-dbc-parsing]
                    [--dbc2val] [--no-dbc2val] [--val2dbc] [--no-val2dbc]
dbcfeeder.py: error: argument --server-type: invalid choice: 'kuksa_databroker' (choose from 'KUKSA_VAL_SERVER', 'KUKSA_DATABROKER')

```

You were also doomed if you used `KUKSA_DATABROKER`

```
erik@debian3:~/kuksa.val.feeders/dbc2val$ ./dbcfeeder.py --server-type KUKSA_DATABROKER
2023-09-19 12:56:22,045 INFO dbcfeeder: Reading configuration from file: config/dbc_feeder.ini
2023-09-19 12:56:22,046 INFO dbcfeeder: DBC2VAL mode is: True
2023-09-19 12:56:22,046 INFO dbcfeeder: VAL2DBC mode is: False
Traceback (most recent call last):
  File "/home/erik/kuksa.val.feeders/dbc2val/./dbcfeeder.py", line 703, in <module>
    sys.exit(main(sys.argv))
  File "/home/erik/kuksa.val.feeders/dbc2val/./dbcfeeder.py", line 608, in main
    kuksa_val_client = _get_kuksa_val_client(args, config)
  File "/home/erik/kuksa.val.feeders/dbc2val/./dbcfeeder.py", line 407, in _get_kuksa_val_client
    server_type = ServerType(server_type_name)
  File "/usr/local/lib/python3.10/enum.py", line 385, in __call__
    return cls.__new__(cls, value)
  File "/usr/local/lib/python3.10/enum.py", line 710, in __new__
    raise ve_exc
ValueError: 'KUKSA_DATABROKER' is not a valid ServerType

```




