### PR TITLE
Remove self-hosted, remove alpine

### DIFF
--- a/.github/workflows/kuksa_csv_provider.yml
+++ b/.github/workflows/kuksa_csv_provider.yml
@@ -52,7 +52,7 @@ jobs:
 
   build-csv-provider-image:
     name: "Build csv provider image"
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: check_ghcr_push
 
     steps:
@@ -74,12 +74,11 @@ jobs:
           type=semver,pattern={{major}}.{{minor}}
           type=semver,pattern={{major}}
 
-    # only needed for runners without buildx setup, will be slow
-    #- name: Set up QEMU
-    #  uses: docker/setup-qemu-action@v2
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
 
-    #- name: Set up Docker Buildx
-    #  uses: docker/setup-buildx-action@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
 
     - name: Log in to the Container registry
       if: needs.check_ghcr_push.outputs.push == 'true'

--- a/.github/workflows/kuksa_dbc_feeder.yml
+++ b/.github/workflows/kuksa_dbc_feeder.yml
@@ -34,7 +34,7 @@ jobs:
 
   build-can-feeder-image:
     name: "Build dbc provider image"
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: check_ghcr_push
 
     steps:
@@ -56,12 +56,11 @@ jobs:
           type=semver,pattern={{major}}.{{minor}}
           type=semver,pattern={{major}}
 
-    # only needed for runners without buildx setup, will be slow
-    #- name: Set up QEMU
-    #  uses: docker/setup-qemu-action@v2
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
 
-    #- name: Set up Docker Buildx
-    #  uses: docker/setup-buildx-action@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
 
     - name: Log in to the Container registry
       if: needs.check_ghcr_push.outputs.push == 'true'

--- a/.github/workflows/kuksa_gps_feeder.yml
+++ b/.github/workflows/kuksa_gps_feeder.yml
@@ -23,103 +23,17 @@ jobs:
     uses: eclipse-kuksa/kuksa-actions/.github/workflows/check_ghcr_push.yml@2
     secrets: inherit
 
-  build-self-hosted:
-    if: ${{ github.repository_owner == 'eclipse' }}
-    runs-on: [ self-hosted ]
-    needs: check_ghcr_push
 
-    # With default permissions, release action fails on forks
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: Docker meta
-      id: meta
-      uses: docker/metadata-action@v4
-      with:
-        # list of Docker images to use as base name for tags
-        images: ghcr.io/${{ github.repository }}/gps
-        # generate Docker tags based on the following events/attributes
-        tags: |
-          type=ref,event=branch
-          type=ref,event=pr
-          type=semver,pattern={{version}}
-          type=semver,pattern={{major}}.{{minor}}
-          type=semver,pattern={{major}}
-
-    - name: Log in to the Container registry
-      if: needs.check_ghcr_push.outputs.push == 'true'
-      uses: docker/login-action@v2
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-
-    - name: Build and push KUKSA gps feeder container image and push to ghcr.io
-      if: needs.check_ghcr_push.outputs.push == 'true'
-      uses: docker/build-push-action@v4
-      with:
-        platforms: |
-          linux/amd64
-          linux/arm64
-        context: gps2val
-        push: true
-        tags: |
-          ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-
-    - name: Posting ghcr.io Summary
-      if: needs.check_ghcr_push.outputs.push == 'true'
-      uses: ./.github/actions/post-container-location
-      with:
-        image: ${{ steps.meta.outputs.tags }}
-        docker-run-args: "-it --rm"
-
-
-    # NOTE: linux/arm64 platform removed as we are getting Error 413 from ttl.sh due to image size.
-    # Only merging to main / release should build multiarch image and push to ghcr.io
-    - name: Build ephemeral KUKSA gps feeder and push to ttl.sh
-      if: needs.check_ghcr_push.outputs.push == 'false'
-      uses: docker/build-push-action@v4
-      with:
-        platforms: |
-          linux/amd64
-        context: gps2val
-        push: true
-        tags: ${{ env.EPHEMERAL_IMAGE }}
-        labels: ${{ steps.meta.outputs.labels }}
-
-    - name: Posting ttl.sh Summary
-      if: needs.check_ghcr_push.outputs.push == 'false'
-      uses: ./.github/actions/post-container-location
-      with:
-        image: ${{ env.EPHEMERAL_IMAGE }}
-        docker-run-args: "-it --rm"
-        message: "**NOTE:** Only **linux/amd64** image is included (ttl.sh push fails on big images)"
-
-
-  build:
-    # we don't have self hosted runners on forked repos, to optimize builds just amd64 image will be built
-    if: ${{ github.repository_owner != 'eclipse' }}
+  build-gps-feeder:
+    name: "Build GPS feeder"
     runs-on: ubuntu-latest
     needs: check_ghcr_push
 
-    # With default permissions, release action fails on forks
-    permissions:
-      contents: read
-      packages: write
-
     steps:
     - uses: actions/checkout@v3
 
-    ## NOTE: Uncomment following step if you want to build arm64 image without self-hosted runner on eclipse. It needs ~3h to finish!
-
-    # - name: Set up QEMU
-    #   uses: docker/setup-qemu-action@v2
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
@@ -147,16 +61,30 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
 
-    - name: Build and push KUKSA gps feeder container image and push to ghcr.io
+    - name: Build and push KUKSA gps feeder container image and push to ghcr.io and ttl.sh
       if: needs.check_ghcr_push.outputs.push == 'true'
       uses: docker/build-push-action@v4
       with:
         platforms: |
           linux/amd64
+          linux/arm64
         context: gps2val
         push: true
         tags: |
           ${{ steps.meta.outputs.tags }}
+          ${{ env.EPHEMERAL_IMAGE }}
+        labels: ${{ steps.meta.outputs.labels }}
+
+    - name: Build ephemeral KUKSA gps feeder and push to ttl.sh
+      if: needs.check_ghcr_push.outputs.push == 'false'
+      uses: docker/build-push-action@v4
+      with:
+        platforms: |
+          linux/amd64
+          linux/arm64
+        context: gps2val
+        push: true
+        tags: ${{ env.EPHEMERAL_IMAGE }}
         labels: ${{ steps.meta.outputs.labels }}
 
     - name: Posting ghcr.io Summary
@@ -165,24 +93,9 @@ jobs:
       with:
         image: ${{ steps.meta.outputs.tags }}
         docker-run-args: "-it --rm"
-        message: "**NOTE:** Only **linux/amd64** image is included (self-hosted runner not available on forks)"
-
-
-    - name: Build ephemeral KUKSA gps feeder and push to ttl.sh
-      if: needs.check_ghcr_push.outputs.push == 'false'
-      uses: docker/build-push-action@v4
-      with:
-        platforms: |
-          linux/amd64
-        context: gps2val
-        push: true
-        tags: ${{ env.EPHEMERAL_IMAGE }}
-        labels: ${{ steps.meta.outputs.labels }}
 
     - name: Posting ttl.sh Summary
-      if: needs.check_ghcr_push.outputs.push == 'false'
       uses: ./.github/actions/post-container-location
       with:
         image: ${{ env.EPHEMERAL_IMAGE }}
         docker-run-args: "-it --rm"
-        message: "**NOTE:** Only **linux/amd64** image is included (self-hosted runner not available on forks)"

--- a/csv_provider/Dockerfile
+++ b/csv_provider/Dockerfile
@@ -13,26 +13,25 @@
 
 
 # Build stage, to create a Virtual Environent
-FROM --platform=$TARGETPLATFORM python:3.10-alpine as builder
+FROM --platform=$TARGETPLATFORM python:3.10-slim-bookworm as builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
 RUN echo "-- Running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
-RUN apk update && apk add alpine-sdk linux-headers
+RUN apt update && apt -yy install binutils git
+
+RUN pip install --upgrade --no-cache-dir pip build pyinstaller
+
+COPY requirements.txt /
+
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+# Copy "all" files first when dependencies have been installed to reuse
+# cached layers as much as possible
 
 COPY . /
-
-RUN python3 -m venv /opt/venv
-
-ENV PATH="/opt/venv/bin:$PATH"
-
-RUN /opt/venv/bin/python3 -m pip install --upgrade pip \
-    && pip3 install --no-cache-dir -r requirements.txt
-
-
-RUN pip3 install wheel scons && pip3 install pyinstaller
 
 RUN pyinstaller --clean -F -s provider.py
 
@@ -42,13 +41,19 @@ WORKDIR /data
 COPY ./signals.csv ./signals.csv
 
 # Runner stage, to copy in the virtual environment and the app
-FROM alpine:3
-
+# Debian 12 is bookworm, so the glibc version matches. Distroless is a lot smaller than
+# Debian slim versions
+# For development add :debug like this
+# FROM gcr.io/distroless/base-debian12:debug  to get a busybox shell as well
+FROM gcr.io/distroless/base-debian12
 
 WORKDIR /dist
 
 COPY --from=builder /dist/* .
 COPY --from=builder /data/ ./
+
+# pyinstaller doesn't pick up transient libz dependency, so copying it manually
+COPY --from=builder /usr/lib/*-linux-gnu/libz.so.1 /lib/
 
 ENV PATH="/dist:$PATH"
 

--- a/dbc2val/Dockerfile
+++ b/dbc2val/Dockerfile
@@ -13,30 +13,35 @@
 
 
 # Build stage, to create a Virtual Environent
-FROM --platform=$TARGETPLATFORM python:3.10-alpine as builder
+FROM --platform=$TARGETPLATFORM python:3.10-slim-bookworm as builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
 RUN echo "-- Running on $BUILDPLATFORM, building for $TARGETPLATFORM"
 
-# cmake and opanblas-dev needed for aarch build
-RUN apk update && apk add alpine-sdk linux-headers cmake openblas-dev
+# It seems 3.10-slim-bookworm shall have gcc, but for aarch64 where it is needed
+# it does not seem to be present, needed to build bitstruct
+# https://github.com/docker-library/python/blob/master/3.10/slim-bookworm/Dockerfile
+RUN apt update && apt -y install \
+    binutils \
+    git \
+    gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --upgrade --no-cache-dir pip build pyinstaller
+
+COPY requirements.txt /
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy "all" files first when dependencies have been installed to reuse
+# cached layers as much as possible
 
 COPY . /
 
-RUN python3 -m venv /opt/venv
-
-ENV PATH="/opt/venv/bin:$PATH"
-
-RUN /opt/venv/bin/python3 -m pip install --upgrade pip \
-    && pip3 install --no-cache-dir -r requirements.txt
-
-
-RUN pip3 install wheel scons && pip3 install pyinstaller
-
-# By default we use certificates and tokens from kuksa_certificates, so they must be included
-RUN pyinstaller --collect-data kuksa_certificates --hidden-import can.interfaces.socketcan --clean -F -s dbcfeeder.py
+# By default we use certificates and tokens from kuksa_client, so they must be included
+RUN pyinstaller --collect-data kuksa_client --hidden-import can.interfaces.socketcan --clean -F -s dbcfeeder.py
 #   --debug=imports
 
 WORKDIR /dist
@@ -46,14 +51,19 @@ COPY ./config/* ./config/
 COPY ./mapping/ ./mapping/
 COPY ./*.dbc ./candump*.log ./*.json ./
 
-# Runner stage, to copy in the virtual environment and the app
-FROM alpine:3
-
+# Debian 12 is bookworm, so the glibc version matches. Distroless is a lot smaller than
+# Debian slim versions
+# For development add :debug like this
+# FROM gcr.io/distroless/base-debian12:debug  to get a busybox shell as well
+FROM gcr.io/distroless/base-debian12
 
 WORKDIR /dist
 
 COPY --from=builder /dist/* .
 COPY --from=builder /data/ ./
+
+# pyinstaller doesn't pick up transient libz dependency, so copying it manually
+COPY --from=builder /usr/lib/*-linux-gnu/libz.so.1 /lib/
 
 ENV PATH="/dist:$PATH"
 

--- a/gps2val/Dockerfile
+++ b/gps2val/Dockerfile
@@ -11,22 +11,26 @@
 # * SPDX-License-Identifier: Apache-2.0
 # ********************************************************************************/
 
-FROM python:3.10-alpine as build
+FROM --platform=$TARGETPLATFORM python:3.10-slim-bookworm as builder
 
-# alpine-sdk and linux-headers needed for Alpine to build grpcio for aarch64, not needed for platforms with prebuilt grpcio
-RUN apk add --no-cache alpine-sdk linux-headers
 ADD . /kuksa_gps_feeder
 WORKDIR /kuksa_gps_feeder
 RUN pip install --upgrade pip
-# Note - Installing grpcio (inherited from kuksa-viss-client) takes very long time (40-60 minutes) on Alpine
-# Note - if relying on kuksa-client pre-releases you must add --pre to the line below
 RUN pip install --target /kuksa_gps_feeder --no-cache-dir -r requirements.txt
 
 
-FROM python:3.10-alpine
+# Debian 12 is bookworm, so the glibc version matches. Distroless is a lot smaller than
+# Debian slim versions
+# For development add :debug like this
+# FROM gcr.io/distroless/base-debian12:debug  to get a busybox shell as well
+FROM --platform=$TARGETPLATFORM python:3.10-slim-bookworm
 
-RUN apk add --no-cache gpsd libstdc++
-COPY --from=build /kuksa_gps_feeder /kuksa_gps_feeder
+RUN apt update && apt install -y gpsd \
+    && rm -rf /var/lib/apt/lists/*
+
+# RUN apk add -yy --no-cache gpsd
+COPY --from=builder /kuksa_gps_feeder /kuksa_gps_feeder
+COPY --from=builder /bin/sh /bin/sh
 WORKDIR /kuksa_gps_feeder
 
 ENV PYTHONUNBUFFERED=yes


### PR DESCRIPTION
Refactoring builds, trying to achieve:

- Remove dependency to self-hosted builder, as the future of that builder is uncertain
- Remove alpine, as that typically leads to very long ghcr build times
- Accept somewhat bigger image size

This should fix the failing builds we are currently experiencing for arm64 for self-hosted.
I have done some basic tests locally.
(This also enables arm builds for gpsfeeder, was previously disabled)