### PR TITLE
Give warning is using dbc2val from this repo

### DIFF
--- a/dbc2val/dbcfeeder.py
+++ b/dbc2val/dbcfeeder.py
@@ -499,6 +499,9 @@ def main(argv):
     args = parser.parse_args()
     config = _parse_config(args.config)
 
+    log.warn("DBC Feeder has migrated to a new repository")
+    log.info("Consider using CAN provider in https://github.com/eclipse-kuksa/kuksa-can-provider instead")
+
     if args.dbc2val:
         use_dbc2val = True
     elif args.no_dbc2val:


### PR DESCRIPTION
This part of the migration process for dbc2val (CAN Feeder). Intention is; as soon as we have created an official release in https://github.com/eclipse-kuksa/kuksa-can-provider this shall happen:

- Merge this
- Tag repo with 0.4.2 (but do not create a release)
- Create dbcfeeder docker container
- Then create a new PR removing all dbc feeder code